### PR TITLE
feat: rotor plugging, speed control tier, header loss, moisture, harv…

### DIFF
--- a/cropThroughput.xml
+++ b/cropThroughput.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    FS25 Realistic Harvesting — Crop Throughput Configuration
+    ==========================================================
+
+    HOW THIS FILE WORKS
+    -------------------
+    The mod derives a power-law throughput curve for each crop using two
+    real-world anchor points taken from AEM combine class data:
+
+        buPerHrMin  = what a CLASS 6  combine  (≈ 280 hp) achieves
+        buPerHrMax  = what a CLASS 10 combine  (≈ 750 hp) achieves
+
+    From those two numbers the mod calculates:
+        throughput (kg/s)  =  A  *  hp ^ B
+
+    where B and A are solved automatically so the curve passes exactly
+    through both anchor points.  Every combine HP between 280 and 750 then
+    falls on the right calibrated curve — small machines land near the min,
+    large machines land near the max.
+
+    WHAT TO TUNE
+    ------------
+    Change buPerHrMin and buPerHrMax to match what your local crop and
+    variety actually produces under good conditions.  You do NOT need to
+    list every crop — any crop not listed here uses the mod's built-in
+    defaults.
+
+    FILE LOCATION
+    -------------
+    This file ships in the mod folder and loads automatically.
+    To override it, copy it to:
+        <My Documents>/My Games/FarmingSimulator2025/
+            modSettings/FS25_RealisticHarvesting/cropThroughput.xml
+    The modSettings copy takes priority over the bundled one.
+
+    BUSHEL WEIGHTS USED (USDA test weight)
+    ----------------------------------------
+    wheat / soybean / legume / potato : 60 lb/bu
+    corn / sorghum                    : 56 lb/bu
+    barley                            : 48 lb/bu
+    canola (rapeseed)                 : 50 lb/bu
+    rice                              : 45 lb/bu
+    oat / cotton                      : 32 lb/bu
+    sunflower                         : 25 lb/bu
+
+    REAL-WORLD ANCHOR REFERENCES
+    (ideal conditions, modern header, proper settings)
+    ---------------------------------------------------
+    Class 6  ≈ 280 hp  e.g. JD S670,   Case IH 7250,  NH CR8.90
+    Class 10 ≈ 750 hp  e.g. JD X9 1100, Case AF9240,  NH CR11
+
+                        Class 6      Class 10
+    Wheat               1,200        3,500 bu/hr
+    Barley              1,400        3,800 bu/hr
+    Oat                 1,200        3,200 bu/hr
+    Corn                2,000        6,000 bu/hr
+    Soybean               900        2,600 bu/hr
+    Canola                700        1,800 bu/hr
+    Sunflower             450        1,100 bu/hr
+    Sorghum             1,200        3,200 bu/hr
+    Rice                  800        2,000 bu/hr
+    Legume/Peas           900        2,600 bu/hr
+
+    PREDICTED MID-RANGE (computed from the defaults above)
+    -------------------------------------------------------
+                        400 hp       500 hp       600 hp
+    Wheat               1,768        2,253        2,747 bu/hr
+    Barley              2,010        2,520        3,031 bu/hr
+    Corn                2,977        3,818        4,678 bu/hr
+    Soybean             1,321        1,680        2,045 bu/hr
+    Canola                985        1,220        1,453 bu/hr
+
+    ALTERNATIVE: SINGLE-POINT MODE (advanced)
+    ------------------------------------------
+    If you only want to set one reference point, use buPerHrRef alone.
+    The mod will treat it as the 400 hp reference and use a fixed exponent
+    of 0.75.  This is less accurate than the two-point form.
+        <crop name="wheat" buPerHrRef="1800" />
+-->
+
+<cropThroughput>
+
+    <!-- ── Grain crops ──────────────────────────────────────────────────── -->
+
+    <crop name="wheat"
+          buPerHrMin="1200"
+          buPerHrMax="3500" />
+
+    <crop name="barley"
+          buPerHrMin="1400"
+          buPerHrMax="3800" />
+
+    <crop name="oat"
+          buPerHrMin="1200"
+          buPerHrMax="3200" />
+
+    <crop name="corn"
+          buPerHrMin="2000"
+          buPerHrMax="6000" />
+
+    <crop name="sorghum"
+          buPerHrMin="1200"
+          buPerHrMax="3200" />
+
+    <crop name="rice"
+          buPerHrMin="800"
+          buPerHrMax="2000" />
+
+    <!-- ── Oilseed and specialty crops ──────────────────────────────────── -->
+
+    <crop name="soybean"
+          buPerHrMin="900"
+          buPerHrMax="2600" />
+
+    <crop name="canola"
+          buPerHrMin="700"
+          buPerHrMax="1800" />
+
+    <crop name="sunflower"
+          buPerHrMin="450"
+          buPerHrMax="1100" />
+
+    <!-- ── Pulse crops ───────────────────────────────────────────────────── -->
+
+    <crop name="legume"
+          buPerHrMin="900"
+          buPerHrMax="2600" />
+
+</cropThroughput>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -2,7 +2,7 @@
 <modDesc descVersion="106">
     <author>exekx</author>
     <manufacturer>exekx</manufacturer>
-    <version>1.4.2.0</version>
+    <version>1.4.3.0</version>
     <modName>FS25_RealisticHarvesting</modName>
     <title>
         <en>Realistic Harvesting</en>
@@ -552,12 +552,13 @@ Funkciók:
         <text name="rhm_ui_load"><en>Engine Load</en><de>Motorlast</de><fr>Charge Moteur</fr><pl>Obciążenie Silnika</pl><es>Carga Motor</es><it>Carico Motore</it><cz>Zatížení Motoru</cz><br>Carga do Motor</br><uk>Навантаження</uk><ru>Нагрузка</ru><hu>Motor Terhelés</hu></text>
         <text name="rhm_ui_loss"><en>Loss</en><de>Verlust</de><fr>Perte</fr><pl>Strata</pl><es>Pérdida</es><it>Perdita</it><cz>Ztráta</cz><br>Perda</br><uk>Втрати</uk><ru>Потери</ru><hu>Veszteség</hu></text>
         
-        <text name="rhm_ui_fan_speed"><en>Fan Speed</en><de>Gebläsedrehzahl</de><fr>Vitesse Ventilateur</fr><pl>Obroty Wentylatora</pl><es>Velocidad Ventilador</es><it>Velocità Ventola</it><cz>Otáčky Ventilátoru</cz><br>Velocidade Ventoinha</br><uk>Оберти Вентилятора</uk><ru>Обороты Вентилятора</ru><hu>Ventilátor Fordulat</hu></text>
-        <text name="rhm_ui_rotor_speed"><en>Rotor Speed</en><de>Rotordrehzahl</de><fr>Vitesse Rotor</fr><pl>Obroty Rotora</pl><es>Velocidad Rotor</es><it>Velocità Rotore</it><cz>Otáčky Rotoru</cz><br>Velocidade Rotor</br><uk>Оберти Ротора</uk><ru>Обороты Ротора</ru><hu>Rotor Fordulat</hu></text>
-        <text name="rhm_ui_upper_sieve"><en>Upper Sieve</en><de>Obersieb</de><fr>Grille Supérieure</fr><pl>Sito Górne</pl><es>Criba Superior</es><it>Crivello Superiore</it><cz>Horní Síto</cz><br>Peneira Superior</br><uk>Верхнє Решето</uk><ru>Верхнее Решето</ru><hu>Felső Rosta</hu></text>
-        <text name="rhm_ui_lower_sieve"><en>Lower Sieve</en><de>Untersieb</de><fr>Grille Inférieure</fr><pl>Sito Dolne</pl><es>Criba Inferior</es><it>Crivello Inferiore</it><cz>Spodní Síto</cz><br>Peneira Inferior</br><uk>Нижнє Решето</uk><ru>Нижнее Решето</ru><hu>Alsó Rosta</hu></text>
-        <text name="rhm_ui_feeder_speed"><en>Feeder House</en><de>Schrägförderer</de><fr>Convoyeur</fr><pl>Przenośnik Pochyły</pl><es>Alimentador</es><it>Canale Elevatore</it><cz>Šikmý Dopravník</cz><br>Alimentador</br><uk>Похила Камера</uk><ru>Наклонная Камера</ru><hu>Ferde Felhordó</hu></text>
-        
+        <text name="rhm_ui_fan_speed"><en>Cleaning Fan</en><de>Gebläse</de><fr>Ventilateur</fr><pl>Wentylator</pl><es>Ventilador</es><it>Ventola</it><cz>Ventilátor</cz><br>Ventoinha</br><uk>Вентилятор очистки</uk><ru>Вентилятор очистки</ru><hu>Ventilátor</hu></text>
+        <text name="rhm_ui_rotor_speed"><en>Rotor / Drum</en><de>Rotor/Trommel</de><fr>Rotor/Tambour</fr><pl>Rotor/Bęben</pl><es>Rotor/Tambor</es><it>Rotore/Tamburo</it><cz>Rotor/Buben</cz><br>Rotor/Tambor</br><uk>Ротор / Барабан</uk><ru>Ротор / Барабан</ru><hu>Rotor/Dob</hu></text>
+        <text name="rhm_ui_upper_sieve"><en>Top Sieve</en><de>Obersieb</de><fr>Grille sup.</fr><pl>Sito górne</pl><es>Criba sup.</es><it>Crivello sup.</it><cz>Horní síto</cz><br>Peneira sup.</br><uk>Верхнє решето</uk><ru>Верхнее решето</ru><hu>Felső rosta</hu></text>
+        <text name="rhm_ui_lower_sieve"><en>Bottom Sieve</en><de>Untersieb</de><fr>Grille inf.</fr><pl>Sito dolne</pl><es>Criba inf.</es><it>Crivello inf.</it><cz>Spodní síto</cz><br>Peneira inf.</br><uk>Нижнє решето</uk><ru>Нижнее решето</ru><hu>Alsó rosta</hu></text>
+        <text name="rhm_ui_feeder_speed"><en>Feeder House</en><de>Schrägförderer</de><fr>Convoyeur</fr><pl>Przenośник</pl><es>Alimentador</es><it>Canale Elevatore</it><cz>Šikmý dopravník</cz><br>Alimentador</br><uk>Похила камера</uk><ru>Наклонная камера</ru><hu>Ferde felhordó</hu></text>
+        <text name="rhm_ui_concave_gap"><en>Concave Gap</en><de>Dreschkorb</de><fr>Jeu Batteur</fr><pl>Szczelina klepiszcza</pl><es>Holgura Cóncavo</es><it>Gioco Barra</it><cz>Vůle mlátidla</cz><br>Folga Côncavo</br><uk>Зазор деки</uk><ru>Зазор деки</ru><hu>Kosár rés</hu></text>
+
         <text name="rhm_ui_mode_auto"><en>AUTO</en><de>AUTO</de><fr>AUTO</fr><pl>AUTO</pl><es>AUTO</es><it>AUTO</it><cz>AUTO</cz><br>AUTO</br><uk>АВТО</uk><ru>АВТО</ru><hu>AUTO</hu></text>
         <text name="rhm_ui_mode_manual"><en>MANUAL</en><de>MANUELL</de><fr>MANUEL</fr><pl>RĘCZNY</pl><es>MANUAL</es><it>MANUALE</it><cz>MANUÁLNÍ</cz><br>MANUAL</br><uk>РУЧНИЙ</uk><ru>РУЧНОЙ</ru><hu>KÉZI</hu></text>
         <text name="rhm_ui_btn_reset"><en>RESET DEFAULT</en><de>STANDARD</de><fr>RÉINIT.</fr><pl>DOMYŚLNE</pl><es>REINICIAR</es><it>REIMPOSTA</it><cz>VÝCHOZÍ</cz><br>RESTAURAR</br><uk>ЗБИТИ</uk><ru>СБРОС</ru><hu>VISSZAÁLLÍTÁS</hu></text>
@@ -620,8 +621,13 @@ Funkciók:
         <!-- ============================= -->
         <!-- CALIBRATION GUI STRINGS       -->
         <!-- ============================= -->
+        <text name="rhm_target_load">
+            <en>Target Engine Load</en><de>Soll-Motorlast</de><fr>Charge Cible</fr>
+            <pl>Docelowe obciążenie</pl><es>Carga Objetivo</es><it>Carico Target</it>
+            <cz>Cílové zatížení</cz><br>Carga Alvo</br><uk>Цільове Навантаження</uk><ru>Целевая Нагрузка</ru><hu>Cél Motorterhelés</hu>
+        </text>
         <text name="rhm_gui_title"><en>Combine Settings</en><de>Mähdreschereinstellungen</de><fr>Paramètres Moissonneuse</fr><pl>Ustawienia Kombajnu</pl><es>Ajustes Cosechadora</es><it>Impostazioni Mietitrebbia</it><cz>Nastavení Kombajnu</cz><uk>Налаштування Комбайна</uk><ru>Настройки Комбайна</ru><hu>Kombájn Beállítások</hu></text>
-        <text name="rhm_gui_crop"><en>Crop:</en><de>Kultur:</de><fr>Culture:</fr><pl>Kultura:</pl><es>Cultivo:</es><it>Coltura:</it><cz>Plodina:</cz><uk>Культура:</uk><ru>Культура:</ru><hu>Növény:</hu></text>
+        <text name="rhm_gui_crop"><en>Crop</en><de>Kultur</de><fr>Culture</fr><pl>Kultura</pl><es>Cultivo</es><it>Coltura</it><cz>Plodina</cz><uk>Культура</uk><ru>Культура</ru><hu>Növény</hu></text>
         <text name="rhm_gui_none"><en>NONE</en><de>KEINE</de><fr>AUCUN</fr><pl>BRAK</pl><es>NINGUNO</es><it>NESSUNO</it><cz>ŽÁDNÁ</cz><uk>НЕМАЄ</uk><ru>НЕТ</ru><hu>NINCS</hu></text>
         <text name="rhm_gui_btn_auto"><en>AUTO</en><de>AUTO</de><fr>AUTO</fr><pl>AUTO</pl><es>AUTO</es><it>AUTO</it><cz>AUTO</cz><uk>АВТО</uk><ru>АВТО</ru><hu>AUTO</hu></text>
         <text name="rhm_gui_btn_load_preset"><en>Load Preset</en><de>Profil laden</de><fr>Charger profil</fr><pl>Wczytaj profil</pl><es>Cargar perfil</es><it>Carica profilo</it><cz>Načíst profil</cz><uk>Завантажити профіль</uk><ru>Загрузить профиль</ru><hu>Profil betöltése</hu></text>
@@ -633,6 +639,16 @@ Funkciók:
         <text name="rhm_gui_close_hint"><en>RShift+K to Close</en><de>RShift+K zum Schließen</de><fr>RShift+K pour fermer</fr><pl>RShift+K aby zamknąć</pl><es>RShift+K para cerrar</es><it>RShift+K per chiudere</it><cz>RShift+K pro zavření</cz><uk>RShift+K щоб закрити</uk><ru>RShift+K чтобы закрыть</ru><hu>RShift+K a bezáráshoz</hu></text>
         <text name="rhm_gui_no_combine"><en>No Combine Selected</en><de>Kein Mähdrescher gewählt</de><fr>Aucune moissonneuse</fr><pl>Brak kombajnu</pl><es>Sin cosechadora</es><it>Nessuna mietitrebbia</it><cz>Žádný kombajn</cz><uk>Комбайн не обрано</uk><ru>Комбайн не выбран</ru><hu>Nincs kombájn kiválasztva</hu></text>
         <text name="rhm_gui_not_init"><en>Combine Not Initialized</en><de>Kombajn nicht initialisiert</de><fr>Moissonneuse non initialisée</fr><pl>Kombajn nie zainicjowany</pl><es>Cosechadora no inicializada</es><it>Mietitrebbia non inizializzata</it><cz>Kombajn neinicializován</cz><uk>Комбайн не ініціалізовано</uk><ru>Комбайн не инициализирован</ru><hu>Kombájn nincs inicializálva</hu></text>
+
+        <text name="rhm_ui_section_separation">
+            <en>Separation</en><uk>Сепарація</uk><de>Abscheidung</de><fr>Séparation</fr><pl>Separacja</pl>
+        </text>
+        <text name="rhm_ui_section_cleaning">
+            <en>Cleaning</en><uk>Очистка</uk><de>Reinigung</de><fr>Nettoyage</fr><pl>Czyszczenie</pl>
+        </text>
+        <text name="rhm_ui_section_performance">
+            <en>Performance</en><uk>Ефективність</uk><de>Leistung</de><fr>Performance</fr><pl>Efektywność</pl>
+        </text>
 
         <!-- ============================= -->
         <!-- MACHINE-TYPE PARAMETER LABELS -->
@@ -860,5 +876,75 @@ Funkciók:
             <ru>КОМБАЙН КРИТИЧЕСКИ ПЕРЕГРУЖЕН! Серьёзные потери урожая!</ru>
             <hu>A KOMBÁJN KRITIKUSAN TÚLTERHELT! Súlyos termésveszteség!</hu>
         </text>
+
+        <!-- ── Rotor plug warning ─────────────────────────────────────────── -->
+        <text name="rhm_warn_rotor_plugged">
+            <en>ROTOR PLUGGED! Reverse and clear the machine.</en>
+            <de>ROTOR VERSTOPFT! Rückwärts fahren und Maschine freimachen.</de>
+            <fr>ROTOR BOUCHÉ ! Faites marche arrière et dégagez la machine.</fr>
+            <pl>ROTOR ZATKANY! Cofnij i oczyść maszynę.</pl>
+            <es>¡ROTOR ATASCADO! Marcha atrás y limpie la máquina.</es>
+            <it>ROTORE INTASATO! Fare retromarcia e liberare la macchina.</it>
+            <cz>ROTOR UCPANÝ! Couvejte a stroj vyčistěte.</cz>
+            <br>ROTOR ENTUPIDO! Dê ré e limpe a máquina.</br>
+            <uk>РОТОР ЗАБИТИЙ! Дайте задній хід та очистіть машину.</uk>
+            <ru>РОТОР ЗАБИТ! Дайте задний ход и очистите машину.</ru>
+            <hu>A ROTOR ELTÖMŐDÖTT! Tolasson hátra és tisztítsa meg a gépet.</hu>
+        </text>
+
+        <!-- ── Rotor plug pre-warning (shown in HUD at 50 %+ plug timer) ─── -->
+        <text name="rhm_warn_plug_risk">
+            <en>PLUG RISK</en>
+            <de>VERSTOPFGEFAHR</de>
+            <fr>RISQUE BOUCHAGE</fr>
+            <pl>RYZYKO ZATKANIA</pl>
+            <es>RIESGO ATASCO</es>
+            <it>RISCHIO INTASAM.</it>
+            <cz>RIZIKO UCPÁNÍ</cz>
+            <br>RISCO DE ENTUPIR</br>
+            <uk>РИЗИК ЗАСМІЧЕННЯ</uk>
+            <ru>РИСК ЗАБИВАНИЯ</ru>
+            <hu>DUGULÁSI KOCKÁZAT</hu>
+        </text>
+
+        <!-- ── HUD labels ─────────────────────────────────────────────────── -->
+        <text name="rhm_hud_thr_label"><en>Thr</en><de>Drsch</de><fr>Bat</fr><pl>Om</pl><es>Tri</es><it>Bat</it><cz>Mlát</cz><br>Bat</br><uk>Мол</uk><ru>Мол</ru><hu>Csép</hu></text>
+        <text name="rhm_hud_hdr_label"><en>Hdr</en><de>Schn</de><fr>Hdr</fr><pl>Pżn</pl><es>Cap</es><it>Tes</it><cz>Hdr</cz><br>Col</br><uk>Жтк</uk><ru>Жтк</ru><hu>Fej</hu></text>
+        <text name="rhm_hud_plugged"><en>PLUGGED</en><de>VERSTOPFT</de><fr>BOUCHÉ</fr><pl>ZATKANY</pl><es>ATASCADO</es><it>INTASATO</it><cz>UCPANÝ</cz><br>ENTUPIDO</br><uk>ЗАБИТИЙ</uk><ru>ЗАБИТ</ru><hu>ELTÖMŐDÖTT</hu></text>
+
+        <!-- ── Moisture labels (HUD) ─────────────────────────────────────── -->
+        <text name="rhm_moisture_morning"><en>Morning dew</en><de>Morgentau</de><fr>Rosée mat.</fr><pl>Poranna rosa</pl><es>Rocío mat.</es><it>Rugiada mat.</it><cz>Ranní rosa</cz><br>Orvalho mat.</br><uk>Ранкова роса</uk><ru>Утренняя роса</ru><hu>Reggeli harmat</hu></text>
+        <text name="rhm_moisture_drying"><en>Drying out</en><de>Trocknet ab</de><fr>Assèchement</fr><pl>Przesychanie</pl><es>Secándose</es><it>Asciugatura</it><cz>Vysychá</cz><br>Secando</br><uk>Підсихає</uk><ru>Просыхает</ru><hu>Szárítás</hu></text>
+        <text name="rhm_moisture_optimal"><en>Optimal</en><de>Optimal</de><fr>Optimal</fr><pl>Optymalny</pl><es>Óptimo</es><it>Ottimale</it><cz>Optimální</cz><br>Ótimo</br><uk>Оптимально</uk><ru>Оптимально</ru><hu>Optimális</hu></text>
+        <text name="rhm_moisture_evening"><en>Evening humidity</en><de>Abendfeuchte</de><fr>Humidité soir</fr><pl>Wilgoć wiecz.</pl><es>Humedad tard.</es><it>Umidità sera</it><cz>Večer. vlhkost</cz><br>Humidade tard.</br><uk>Вечірня вологість</uk><ru>Вечерняя влажность</ru><hu>Esti páratartalom</hu></text>
+        <text name="rhm_moisture_dew"><en>Evening dew</en><de>Abendtau</de><fr>Rosée soir</fr><pl>Wieczorna rosa</pl><es>Rocío tard.</es><it>Rugiada sera</it><cz>Večerní rosa</cz><br>Orvalho tard.</br><uk>Вечірня роса</uk><ru>Вечерняя роса</ru><hu>Esti harmat</hu></text>
+        <text name="rhm_moisture_night"><en>Night moisture</en><de>Nachtfeuchte</de><fr>Humidité nuit</fr><pl>Wilgoć nocy</pl><es>Humedad noche</es><it>Umidità notte</it><cz>Noční vlhkost</cz><br>Humidade noite</br><uk>Нічна вологість</uk><ru>Ночная влажность</ru><hu>Éjszakai nedvesség</hu></text>
+
+        <!-- ── Harvest Report section (CombineCalibrationGUI) ────────────── -->
+        <text name="rhm_report_title"><en>HARVEST REPORT</en><de>ERNTEBERICHT</de><fr>RAPPORT RÉCOLTE</fr><pl>RAPORT ZBIORU</pl><es>INFORME COSECHA</es><it>RAPPORTO RACCOLTO</it><cz>ZPRÁVA O SKLIZNI</cz><br>RELATÓRIO COLHEITA</br><uk>ЗВІТ ПРО ЖНИВА</uk><ru>ОТЧЁТ О ЖАТВЕ</ru><hu>BETAKARÍTÁSI JELENTÉS</hu></text>
+        <text name="rhm_report_time"><en>Time</en><de>Zeit</de><fr>Durée</fr><pl>Czas</pl><es>Tiempo</es><it>Tempo</it><cz>Čas</cz><br>Tempo</br><uk>Час</uk><ru>Время</ru><hu>Idő</hu></text>
+        <text name="rhm_report_area"><en>Area</en><de>Fläche</de><fr>Surface</fr><pl>Powierzchnia</pl><es>Área</es><it>Area</it><cz>Plocha</cz><br>Área</br><uk>Площа</uk><ru>Площадь</ru><hu>Terület</hu></text>
+        <text name="rhm_report_yield"><en>Yield</en><de>Ertrag</de><fr>Rendement</fr><pl>Plon</pl><es>Rendimiento</es><it>Resa</it><cz>Výnos</cz><br>Rendimento</br><uk>Врожайність</uk><ru>Урожайность</ru><hu>Hozam</hu></text>
+        <text name="rhm_report_avg_load"><en>Avg Load</en><de>Ø Last</de><fr>Chrg moy.</fr><pl>Śr. obsz.</pl><es>Carga med.</es><it>Carico med.</it><cz>Průměr. zat.</cz><br>Carga méd.</br><uk>Сер. нав.</uk><ru>Сред. нагр.</ru><hu>Átl. terhelés</hu></text>
+        <text name="rhm_report_peak_load"><en>Peak Load</en><de>Max Last</de><fr>Chrg max.</fr><pl>Maks. obsz.</pl><es>Carga máx.</es><it>Carico mas.</it><cz>Max. zatíž.</cz><br>Carga máx.</br><uk>Пік нав.</uk><ru>Пик нагр.</ru><hu>Csúcsterhelés</hu></text>
+        <text name="rhm_report_thr_loss"><en>Thr Loss</en><de>Dresch.verl.</de><fr>Perte bat.</fr><pl>Str. omł.</pl><es>Pérd. tri.</es><it>Perd. bat.</it><cz>Ztr. mlát.</cz><br>Perd. bat.</br><uk>Втр. мол.</uk><ru>Пот. мол.</ru><hu>Csép. veszt.</hu></text>
+        <text name="rhm_report_hdr_loss"><en>Hdr Loss</en><de>Schn.verl.</de><fr>Perte hdr.</fr><pl>Str. żniwna</pl><es>Pérd. cap.</es><it>Perd. tes.</it><cz>Ztr. hdr.</cz><br>Perd. col.</br><uk>Втр. жтк.</uk><ru>Пот. жтк.</ru><hu>Fej. veszt.</hu></text>
+        <text name="rhm_report_plugs"><en>Plugs</en><de>Verstopf.</de><fr>Bouchages</fr><pl>Zatk.</pl><es>Atascos</es><it>Intasat.</it><cz>Ucpání</cz><br>Entupim.</br><uk>Засміч.</uk><ru>Забивания</ru><hu>Dugulások</hu></text>
+        <text name="rhm_report_grade"><en>Grade</en><de>Note</de><fr>Note</fr><pl>Ocena</pl><es>Calificación</es><it>Voto</it><cz>Hodnocení</cz><br>Nota</br><uk>Оцінка</uk><ru>Оценка</ru><hu>Osztályzat</hu></text>
+        <text name="rhm_report_reset"><en>RESET SESSION</en><de>SITZUNG RESET</de><fr>RÉI. SESSION</fr><pl>RESETUJ SESJĘ</pl><es>REINICIAR SESIÓN</es><it>AZZERA SESSIONE</it><cz>RESETOVAT RELACI</cz><br>RESETAR SESSÃO</br><uk>СКИНУТИ СЕСІЮ</uk><ru>СБРОС СЕССИИ</ru><hu>MUNKAMENET RESET</hu></text>
+        <text name="rhm_report_no_data"><en>No harvest data yet</en><de>Noch keine Erntedaten</de><fr>Aucune donnée récoltée</fr><pl>Brak danych zbioru</pl><es>Sin datos de cosecha</es><it>Nessun dato raccolto</it><cz>Žádná data o sklizni</cz><br>Sem dados de colheita</br><uk>Даних про жнива ще немає</uk><ru>Данных о жатве пока нет</ru><hu>Még nincs betakarítási adat</hu></text>
+
+        <!-- ── Upgrade tier descriptions ─────────────────────────────────── -->
+        <text name="rhm_upgrade_tier0_name"><en>No Upgrade</en><de>Kein Upgrade</de><fr>Sans amélioration</fr><pl>Bez ulepszeń</pl><es>Sin mejora</es><it>Nessun upgrade</it><cz>Bez upgradu</cz><br>Sem melhoria</br><uk>Без покращень</uk><ru>Без улучшения</ru><hu>Nincs fejlesztés</hu></text>
+        <text name="rhm_upgrade_tier1_name"><en>Calibration System</en><de>Kalibrierungssystem</de><fr>Système étalonnage</fr><pl>System kalibracji</pl><es>Sistema calibración</es><it>Sistema calibrazione</it><cz>Kalibrační systém</cz><br>Sistema calibração</br><uk>Система калібрування</uk><ru>Система калибровки</ru><hu>Kalibrálórendszer</hu></text>
+        <text name="rhm_upgrade_tier2_name"><en>Machine Monitor</en><de>Maschinenmonitor</de><fr>Moniteur machine</fr><pl>Monitor maszyny</pl><es>Monitor máquina</es><it>Monitor macchina</it><cz>Monitor stroje</cz><br>Monitor máquina</br><uk>Монітор машини</uk><ru>Монитор машины</ru><hu>Gépmonitor</hu></text>
+        <text name="rhm_upgrade_tier3_name"><en>Speed Control</en><de>Geschwindigkeitsregelung</de><fr>Contrôle vitesse</fr><pl>Kontrola prędkości</pl><es>Control velocidad</es><it>Controllo velocità</it><cz>Řízení rychlosti</cz><br>Controle velocidade</br><uk>Контроль швидкості</uk><ru>Контроль скорости</ru><hu>Sebességszabályozás</hu></text>
+        <text name="rhm_upgrade_tier4_name"><en>Auto Pilot</en><de>Autopilot</de><fr>Pilote automatique</fr><pl>Autopilot</pl><es>Piloto automático</es><it>Pilota automatico</it><cz>Autopilot</cz><br>Piloto automático</br><uk>Автопілот</uk><ru>Автопилот</ru><hu>Automata vezető</hu></text>
+
+        <!-- ── Dynamic hints (Tier 2 stats bar) ─────────────────────────── -->
+        <text name="rhm_hint_slow_down"><en>Load high — slow down!</en><de>Last hoch — langsamer!</de><fr>Charge élevée — ralentir !</fr><pl>Duże obciążenie — zwolnij!</pl><es>Carga alta — ¡reducir velocidad!</es><it>Carico alto — rallentare!</it><cz>Zatížení vysoké — zpomalte!</cz><br>Carga alta — reduza!</br><uk>Навантаження висок. — сповільніть!</uk><ru>Нагрузка высокая — сбавьте скорость!</ru><hu>Magas terhelés — lassítson!</hu></text>
+        <text name="rhm_hint_hdr_loss"><en>Hdr loss — reduce speed</en><de>Schn.verlust — langsamer</de><fr>Perte hdr — réduire vitesse</fr><pl>Str. żniwna — zwolnij</pl><es>Pérd. cap — reducir vel.</es><it>Perd. tes — ridurre vel.</it><cz>Ztr. hdr — zpomalte</cz><br>Perd. col — reduzir vel.</br><uk>Втр. жтк — знизьте швидкість</uk><ru>Пот. жтк — снизьте скорость</ru><hu>Fejveszteség — lassítson</hu></text>
+        <text name="rhm_hint_check_settings"><en>Check settings for crop</en><de>Einstellungen prüfen</de><fr>Vérifier réglages culture</fr><pl>Sprawdź ustawienia</pl><es>Revisar ajustes cultivo</es><it>Controlla impostazioni</it><cz>Zkontrolujte nastavení</cz><br>Verificar configurações</br><uk>Перевірте налаштування</uk><ru>Проверьте настройки</ru><hu>Ellenőrizze a beállításokat</hu></text>
+        <text name="rhm_hint_speed_up"><en>Under-utilized — increase speed</en><de>Unterausgelastet — schneller!</de><fr>Sous-utilisé — accélérer</fr><pl>Niedobciążony — przyspiesz</pl><es>Bajo uso — aumentar vel.</es><it>Sotto-utilizzato — accelerare</it><cz>Nedostatečné zatížení — zrychlete</cz><br>Subutilizado — aumentar vel.</br><uk>Недозавантажений — збільшіть швидкість</uk><ru>Недогруженный — ускорьтесь</ru><hu>Kihasználatlan — gyorsítson</hu></text>
     </l10n>
 </modDesc>

--- a/src/config/CropThroughputConfig.lua
+++ b/src/config/CropThroughputConfig.lua
@@ -1,0 +1,220 @@
+-- EN: Per-crop throughput curve config for Realistic Harvesting.
+--     Reads cropThroughput.xml and derives a power-law throughput curve for each
+--     crop from two real-world anchor points:
+--
+--         buPerHrMin  →  throughput a CLASS 6  (≈280 hp) combine achieves
+--         buPerHrMax  →  throughput a CLASS 10 (≈750 hp) combine achieves
+--
+--     From those two points the module derives a per-crop power-law:
+--
+--         throughput_kg_s  =  A  *  hp ^ B
+--
+--     where B is calculated from the ratio of the anchor throughputs and the
+--     ratio of the anchor HPs.  This means every combine HP between 280–750
+--     lands exactly on the right curve — smaller machines hit the lower bound,
+--     larger machines hit the upper bound, with realistic scaling in between.
+--
+--     Load priority:
+--         1. <My Documents>/My Games/FarmingSimulator2025/
+--                modSettings/FS25_RealisticHarvesting/cropThroughput.xml  (user override)
+--         2. <ModDirectory>/cropThroughput.xml  (bundled default — works out of the box)
+--
+-- UA: Конфігурація кривої продуктивності по культурах для Realistic Harvesting.
+--     Читає cropThroughput.xml та будує степеневу криву для кожної культури
+--     з двох реальних опорних точок: мінімальна (280 к.с.) та максимальна (750 к.с.).
+
+CropThroughputConfig = {}
+
+-- EN: Loaded curve params per crop: cropKey → { coef=A, exp=B }
+-- UA: Параметри кривої по культурах: назва → { coef=A, exp=B }
+CropThroughputConfig._data   = {}
+CropThroughputConfig._loaded = false
+CropThroughputConfig._source = "none"   -- "user", "bundled", or "none"
+
+-- ---------------------------------------------------------------------------
+-- EN: AEM combine class HP anchor points.
+--     Min = Class 6 lower end, Max = Class 10 / AF11 upper end.
+-- UA: Опорні точки к.с. по класах AEM.
+-- ---------------------------------------------------------------------------
+local HP_MIN = 280.0   -- AEM Class 6 (e.g. JD S670, Case 7250)
+local HP_MAX = 750.0   -- AEM Class 10 / AF11 (e.g. JD X9 1100, Case AF9240)
+local REF_HP = 400.0   -- Reference HP used when only buPerHrRef is supplied
+
+-- ---------------------------------------------------------------------------
+-- EN: USDA standard test weights (lbs/bu) — authoritative conversion factors.
+-- UA: Стандартна вага бушеля USDA (фунти/бу).
+-- ---------------------------------------------------------------------------
+local BUSHEL_LBS = {
+    wheat      = 60,
+    barley     = 48,
+    oat        = 32,
+    corn       = 56,
+    soybean    = 60,
+    canola     = 50,    -- rapeseed; close to 52 lbs, 50 is the common round figure
+    sunflower  = 25,    -- hulled sunflower seed
+    sorghum    = 56,
+    rice       = 45,
+    legume     = 60,    -- generic pulse/legume (peas, beans ≈ 60 lbs/bu)
+    potato     = 60,
+    sugarbeet  = 60,
+    cotton     = 32,
+}
+
+local LBS_PER_KG = 2.20462
+
+-- EN: Convert bu/hr to kg/s using USDA test weight.
+-- UA: Конвертуємо бу/год в кг/с за вагою бушеля USDA.
+local function buPerHrToKgPerSec(buPerHr, cropKey)
+    local lbsPerBu = BUSHEL_LBS[cropKey] or 56
+    return (buPerHr * lbsPerBu / LBS_PER_KG) / 3600.0
+end
+
+-- ---------------------------------------------------------------------------
+-- EN: Resolve config XML path.
+--     User's modSettings file takes priority; falls back to bundled default.
+-- UA: Визначаємо шлях до XML.  Файл користувача має пріоритет; далі — вбудований.
+-- ---------------------------------------------------------------------------
+local function getConfigPath()
+    -- EN: User override location.
+    local userPath = getUserProfileAppPath()
+                   .. "modSettings/FS25_RealisticHarvesting/cropThroughput.xml"
+    if fileExists(userPath) then
+        return userPath, "user"
+    end
+    -- EN: Bundled default shipped with the mod.
+    local bundledPath = (g_currentModDirectory or "") .. "cropThroughput.xml"
+    if fileExists(bundledPath) then
+        return bundledPath, "bundled"
+    end
+    return nil, "none"
+end
+
+-- ---------------------------------------------------------------------------
+-- EN: Derive power-law curve parameters from two anchor points.
+--
+--     throughput = A * hp^B
+--
+--     Solving from (HP_MIN, kgsMin) and (HP_MAX, kgsMax):
+--         B = ln(kgsMax / kgsMin) / ln(HP_MAX / HP_MIN)
+--         A = kgsMin / HP_MIN^B
+--
+-- UA: Виводимо параметри степеневої кривої з двох опорних точок.
+-- ---------------------------------------------------------------------------
+local function deriveCurve(kgsMin, kgsMax)
+    -- EN: Guard against zero / negative throughput values in the XML.
+    if kgsMin <= 0 or kgsMax <= 0 then return nil end
+
+    local B = math.log(kgsMax / kgsMin) / math.log(HP_MAX / HP_MIN)
+    local A = kgsMin / (HP_MIN ^ B)
+    return { coef = A, exp = B }
+end
+
+-- ---------------------------------------------------------------------------
+-- EN: Load and parse the crop throughput XML.
+--     Called from main.lua after mission load (after UnitConverter.initBushelCoefficients).
+-- UA: Завантажуємо та розбираємо XML продуктивності культур.
+-- ---------------------------------------------------------------------------
+function CropThroughputConfig.load()
+    CropThroughputConfig._data   = {}
+    CropThroughputConfig._loaded = false
+    CropThroughputConfig._source = "none"
+
+    local path, source = getConfigPath()
+    if not path then
+        Logging.info("[RHM] CropThroughputConfig: no config found, using built-in defaults.")
+        return
+    end
+
+    local xmlFile = loadXMLFile("CropThroughputConfig", path)
+    if not xmlFile then
+        Logging.warning("[RHM] CropThroughputConfig: failed to parse " .. path)
+        return
+    end
+
+    local count = 0
+    local i = 0
+    while true do
+        local key = string.format("cropThroughput.crop(%d)", i)
+        if not hasXMLProperty(xmlFile, key) then break end
+
+        local name  = getXMLString(xmlFile, key .. "#name")
+        local buMin = getXMLFloat (xmlFile, key .. "#buPerHrMin")
+        local buMax = getXMLFloat (xmlFile, key .. "#buPerHrMax")
+        local buRef = getXMLFloat (xmlFile, key .. "#buPerHrRef")
+
+        if name then
+            local cropKey = name:lower()
+
+            if buMin and buMax and buMin > 0 and buMax > 0 then
+                -- EN: Two-point anchor → derive per-crop power-law curve.
+                -- UA: Дві опорні точки → виводимо криву степеневого закону для культури.
+                local kgsMin = buPerHrToKgPerSec(buMin, cropKey)
+                local kgsMax = buPerHrToKgPerSec(buMax, cropKey)
+                local curve  = deriveCurve(kgsMin, kgsMax)
+                if curve then
+                    CropThroughputConfig._data[cropKey] = curve
+                    count = count + 1
+                end
+
+            elseif buRef and buRef > 0 then
+                -- EN: Single reference point at REF_HP (400hp) — use default exponent 0.75.
+                --     This mode is supported for simple setups but the two-point form
+                --     (buPerHrMin + buPerHrMax) is strongly recommended.
+                -- UA: Одна еталонна точка при 400 к.с. — використовуємо показник 0.75.
+                local kgsRef = buPerHrToKgPerSec(buRef, cropKey)
+                local A = kgsRef / (REF_HP ^ 0.75)
+                CropThroughputConfig._data[cropKey] = { coef = A, exp = 0.75 }
+                count = count + 1
+            end
+        end
+
+        i = i + 1
+    end
+
+    deleteXMLFile(xmlFile)
+    CropThroughputConfig._loaded = true
+    CropThroughputConfig._source = source
+
+    Logging.info(string.format(
+        "[RHM] CropThroughputConfig: loaded %d crops from %s config (%s)",
+        count, source, path))
+end
+
+-- ---------------------------------------------------------------------------
+-- EN: Return the power-law curve params {coef, exp} for a crop, or nil.
+--     Called from LoadCalculator.getBasePerformanceFromPower().
+--
+--     Usage:
+--         local p = CropThroughputConfig.getCurveParams(cropName)
+--         if p then basePerf = p.coef * (hp ^ p.exp) end
+--
+-- UA: Повертає параметри кривої {coef, exp} для культури або nil.
+-- ---------------------------------------------------------------------------
+function CropThroughputConfig.getCurveParams(cropName)
+    if not cropName then return nil end
+    return CropThroughputConfig._data[cropName:lower()]
+end
+
+-- ---------------------------------------------------------------------------
+-- EN: Debug helper — log predicted throughput at several HP points for one crop.
+-- UA: Допоміжна функція для налагодження — виводить прогнозовану продуктивність.
+-- ---------------------------------------------------------------------------
+function CropThroughputConfig.debugCrop(cropName)
+    local p = CropThroughputConfig.getCurveParams(cropName)
+    if not p then
+        print("[RHM] CropThroughputConfig: no curve for '" .. tostring(cropName) .. "'")
+        return
+    end
+    local lbsPerBu = BUSHEL_LBS[cropName:lower()] or 56
+    local kgPerBu  = lbsPerBu / LBS_PER_KG
+    local function predict(hp)
+        local kgs   = p.coef * (hp ^ p.exp)
+        local buHr  = kgs * 3600 / kgPerBu
+        return string.format("%4d hp → %6.1f bu/hr  (%5.2f kg/s)", hp, buHr, kgs)
+    end
+    print(string.format("[RHM] CropThroughputConfig '%s': coef=%.6f  exp=%.4f",
+        cropName, p.coef, p.exp))
+    for _, hp in ipairs({280, 320, 380, 450, 520, 600, 700, 750}) do
+        print("  " .. predict(hp))
+    end
+end

--- a/src/data/CombineSettingsDatabase.lua
+++ b/src/data/CombineSettingsDatabase.lua
@@ -1,7 +1,9 @@
 -- EN: Static database of optimal combine settings and crop profiles.
---     Stores parameter templates (fan, rotor, sieves, feeder) for every supported crop type,
+--     Stores parameter templates (fan, rotor, sieves, concave) for every supported crop type,
 --     maps FS25 FillType enums to internal crop names, and defines which parameters are
 --     active for each machine type (grain, forage, root, cotton).
+--     NOTE: Grain combines use 'concave' (0-50mm clearance) instead of 'feeder'.
+--           Forage/root/cotton harvesters still use 'feeder' (feed roll speed).
 -- UA: Статична база даних оптимальних налаштувань комбайна та профілів культур.
 --     Зберігає шаблони параметрів (вентилятор, ротор, решета, подача) для кожного типу культури,
 --     відображає FillType enum FS25 на внутрішні назви культур, і визначає які параметри активні
@@ -13,99 +15,95 @@ CombineSettingsDatabase = {}
 -- UA: Базові шаблони для груп культур. Кожен параметр має: optimal, min, max, tolerance.
 --     Значення виражені у відсотках (0-100) що представляють відповідний фізичний діапазон.
 local templates = {
-    -- EN: Standard grain cereals — Wheat/Rye/Spelt/Triticale. Rotor 560-850rpm (avg 56%), Fan 800rpm (56%), Upper 14mm (47%), Lower 8mm (32%).
-    -- UA: Стандартні зернові — Пшениця/Жито/Спельта/Тритикале. Ротор 560-850об/хв (сер. 56%), Вентилятор 800об/хв (56%), Верх 14мм (47%), Низ 8мм (32%).
+    -- EN: Standard grain cereals — Wheat/Rye/Spelt/Triticale. Rotor 560-850rpm (avg 56%), Fan 800rpm (56%), Chaffer 14mm (47%), Sieve 8mm (32%), Concave 25mm (50%).
+    -- UA: Стандартні зернові — Пшениця/Жито/Спельта/Тритикале. Ротор 560-850об/хв (сер. 56%), Вентилятор 800об/хв (56%), Верх 14мм (47%), Низ 8мм (32%), Деко 25мм (50%).
     wheat = {
         fan = {optimal = 56, min = 40, max = 70, tolerance = 7},
         upperSieve = {optimal = 47, min = 35, max = 60, tolerance = 6},
         lowerSieve = {optimal = 32, min = 20, max = 45, tolerance = 6},
         rotor = {optimal = 56, min = 45, max = 70, tolerance = 6},
-        feeder = {optimal = 50, min = 35, max = 65, tolerance = 10},
+        concave = {optimal = 50, min = 35, max = 65, tolerance = 10},  -- 0-50mm: 50% = 25mm
     },
 
-    -- Barley - Drum speed 640-900 (Avg 770 = 63%), Fan 800 (56%), Upper 14mm (47%), Lower 8mm (32%)
+    -- Barley - Drum speed 640-900 (Avg 770 = 63%), Fan 800 (56%), Chaffer 14mm (47%), Sieve 8mm (32%)
     barley = {
         fan = {optimal = 56, min = 40, max = 70, tolerance = 7},
         upperSieve = {optimal = 47, min = 35, max = 60, tolerance = 6},
         lowerSieve = {optimal = 32, min = 20, max = 45, tolerance = 6},
         rotor = {optimal = 63, min = 50, max = 75, tolerance = 6},
-        feeder = {optimal = 50, min = 35, max = 65, tolerance = 10},
+        concave = {optimal = 50, min = 35, max = 65, tolerance = 10},
     },
 
-    -- Oat - Drum speed 640-800 = 720 = 58%, Fan 700 = 44%, Upper 10mm = 33%, Lower 6mm = 24%
+    -- Oat - Drum speed 640-800 = 720 = 58%, Fan 700 = 44%, Chaffer 10mm = 33%, Sieve 6mm = 24%
     oat = {
         fan = {optimal = 44, min = 30, max = 60, tolerance = 7},
         upperSieve = {optimal = 33, min = 20, max = 50, tolerance = 6},
         lowerSieve = {optimal = 24, min = 15, max = 40, tolerance = 6},
         rotor = {optimal = 58, min = 45, max = 75, tolerance = 6},
-        feeder = {optimal = 50, min = 35, max = 65, tolerance = 10},
+        concave = {optimal = 50, min = 35, max = 65, tolerance = 10},
     },
-    
-    -- Легкі зернові (овес)
-    -- Canola (Rape Seed) - Drum speed 480-520 (Avg 500 = 33%), Fan 650 (39%)
+
+    -- Canola (Rape Seed) - Drum speed 480-520 (Avg 500 = 33%), Fan 650 (39%), tight concave ~10mm (20%)
     canola = {
         fan = {optimal = 39, min = 25, max = 55, tolerance = 6},
         upperSieve = {optimal = 40, min = 25, max = 55, tolerance = 4},
         lowerSieve = {optimal = 25, min = 15, max = 40, tolerance = 4},
         rotor = {optimal = 33, min = 20, max = 45, tolerance = 6},
-        feeder = {optimal = 45, min = 30, max = 60, tolerance = 8},
+        concave = {optimal = 22, min = 10, max = 35, tolerance = 6},   -- tighter: ~11mm
     },
-    
-    -- Легкі олійні (ріпак)
-    -- Soya Bean - Drum speed 550 rpm (39%), Fan 850 rpm (61%), Upper 15mm (50%), Lower 10mm (40%)
+
+    -- Soya Bean - Drum speed 550 rpm (39%), Fan 850 rpm (61%), Chaffer 15mm (50%), Sieve 10mm (40%)
     soybean = {
         fan = {optimal = 61, min = 45, max = 75, tolerance = 7},
         upperSieve = {optimal = 50, min = 35, max = 65, tolerance = 6},
         lowerSieve = {optimal = 40, min = 25, max = 55, tolerance = 6},
         rotor = {optimal = 39, min = 25, max = 55, tolerance = 6},
-        feeder = {optimal = 45, min = 30, max = 60, tolerance = 8},
+        concave = {optimal = 45, min = 30, max = 60, tolerance = 8},   -- ~22mm
     },
-    
-    -- Важкі олійні (соняшник)
-    -- Sunflower - Drum speed 320 rpm (13%), Fan 700 rpm (44%)
+
+    -- Sunflower - Drum speed 320 rpm (13%), Fan 700 rpm (44%), wide concave ~30mm (60%)
     sunflower = {
         fan = {optimal = 44, min = 30, max = 60, tolerance = 7},
         upperSieve = {optimal = 60, min = 45, max = 75, tolerance = 6},
         lowerSieve = {optimal = 45, min = 30, max = 60, tolerance = 6},
         rotor = {optimal = 13, min = 5, max = 25, tolerance = 5},
-        feeder = {optimal = 60, min = 45, max = 75, tolerance = 10},
+        concave = {optimal = 60, min = 45, max = 75, tolerance = 10},  -- wide: ~30mm
     },
 
-    -- Sorghum - Drum speed 640 = 49%, Fan 700-800 = 750 = 50%, Upper 10mm = 33%, Lower 8mm = 32%
+    -- Sorghum - Drum speed 640 = 49%, Fan 700-800 = 750 = 50%, Chaffer 10mm = 33%, Sieve 8mm = 32%
     sorghum = {
         fan = {optimal = 50, min = 35, max = 65, tolerance = 7},
         upperSieve = {optimal = 33, min = 20, max = 45, tolerance = 6},
         lowerSieve = {optimal = 32, min = 20, max = 45, tolerance = 6},
         rotor = {optimal = 49, min = 35, max = 65, tolerance = 6},
-        feeder = {optimal = 50, min = 35, max = 65, tolerance = 10},
+        concave = {optimal = 50, min = 35, max = 65, tolerance = 10},
     },
-    
-    -- Кукурудза
-    -- Maize (Corn) - Drum speed 320-400 (Avg 360 = 18%), Fan 900 (67%), Upper 18mm (60%), Lower 12mm (48%)
+
+    -- Maize (Corn) - Drum speed 320-400 (Avg 360 = 18%), Fan 900 (67%), Chaffer 18mm (60%), Sieve 12mm (48%), wide concave ~35mm (70%)
     corn = {
         fan = {optimal = 67, min = 50, max = 85, tolerance = 6},
         upperSieve = {optimal = 60, min = 45, max = 75, tolerance = 6},
         lowerSieve = {optimal = 48, min = 35, max = 65, tolerance = 6},
         rotor = {optimal = 18, min = 5, max = 30, tolerance = 5},
-        feeder = {optimal = 70, min = 55, max = 85, tolerance = 10},
+        concave = {optimal = 70, min = 55, max = 85, tolerance = 10},  -- wide: ~35mm
     },
-    
-    -- Бобові (Beans/Peas) - Drum speed 320-360 = 340 = 16%, Fan 800-950 = 875 = 64%, Upper 15mm = 50%, Lower 10mm = 40%
+
+    -- Beans/Peas - Drum speed 320-360 = 340 = 16%, Fan 800-950 = 875 = 64%, Chaffer 15mm = 50%, Sieve 10mm = 40%
     legume = {
         fan = {optimal = 64, min = 50, max = 80, tolerance = 7},
         upperSieve = {optimal = 50, min = 35, max = 65, tolerance = 6},
         lowerSieve = {optimal = 40, min = 25, max = 55, tolerance = 6},
         rotor = {optimal = 16, min = 5, max = 30, tolerance = 5},
-        feeder = {optimal = 45, min = 30, max = 60, tolerance = 8},
+        concave = {optimal = 45, min = 30, max = 60, tolerance = 8},
     },
     
-    -- Rice - Drum speed 450-650 = 550 = 39%, Fan 700-850 = 775 = 53%, Upper 14mm = 47%, Lower 8mm = 32%
+    -- Rice - Drum speed 450-650 = 550 = 39%, Fan 700-850 = 775 = 53%, Chaffer 14mm = 47%, Sieve 8mm = 32%
     rice = {
         fan = {optimal = 53, min = 40, max = 70, tolerance = 7},
         upperSieve = {optimal = 47, min = 35, max = 60, tolerance = 6},
         lowerSieve = {optimal = 32, min = 20, max = 45, tolerance = 6},
         rotor = {optimal = 39, min = 25, max = 55, tolerance = 6},
-        feeder = {optimal = 50, min = 35, max = 65, tolerance = 10},
+        concave = {optimal = 50, min = 35, max = 65, tolerance = 10},
     },
     
     -- Коренеплоди важкі (Картопля, Буряк)
@@ -227,58 +225,67 @@ local templates = {
         feeder = {optimal = 55, min = 35, max = 75, tolerance = 10},
     },
 
-    -- Chickpea (Garbanzos) - Rotor 300-500 = 400 = 22%, Fan 800-1100 = 950 = 72%, Upper 12-16 = 14mm = 47%, Lower 6-10 = 8mm = 32%
+    -- Chickpea (Garbanzos) - Rotor 300-500 = 400 = 22%, Fan 800-1100 = 950 = 72%, Chaffer 14mm = 47%, Sieve 8mm = 32%
     chickpea = {
         fan = {optimal = 72, min = 55, max = 85, tolerance = 8},
         upperSieve = {optimal = 47, min = 35, max = 60, tolerance = 5},
         lowerSieve = {optimal = 32, min = 20, max = 45, tolerance = 4},
         rotor = {optimal = 22, min = 10, max = 35, tolerance = 5},
-        feeder = {optimal = 70, min = 55, max = 85, tolerance = 8},
+        concave = {optimal = 70, min = 55, max = 85, tolerance = 8},
     },
 
-    -- Lentil (Lentejas) - Rotor 300-500 = 400 = 22%, Fan 700-850 = 775 = 53%, Upper 10-15 = 12.5mm = 42%, Lower 4-7 = 5.5mm = 22%
+    -- Lentil (Lentejas) - Rotor 300-500 = 400 = 22%, Fan 700-850 = 775 = 53%, Chaffer 12.5mm = 42%, Sieve 5.5mm = 22%
     lentil = {
         fan = {optimal = 53, min = 40, max = 65, tolerance = 7},
         upperSieve = {optimal = 42, min = 30, max = 55, tolerance = 6},
         lowerSieve = {optimal = 22, min = 10, max = 35, tolerance = 6},
         rotor = {optimal = 22, min = 10, max = 35, tolerance = 5},
-        feeder = {optimal = 70, min = 55, max = 85, tolerance = 8},
+        concave = {optimal = 70, min = 55, max = 85, tolerance = 8},
     },
 
-    -- Flax / Linseed - Drum speed 640-800 = 720 = 58%, Fan 600 = 33%, Upper 10mm = 33%, Lower 4mm = 16%
+    -- Flax / Linseed - Drum speed 640-800 = 720 = 58%, Fan 600 = 33%, Chaffer 10mm = 33%, Sieve 4mm = 16%
     flax = {
         fan = {optimal = 33, min = 20, max = 50, tolerance = 7},
         upperSieve = {optimal = 33, min = 20, max = 50, tolerance = 5},
         lowerSieve = {optimal = 16, min = 5, max = 30, tolerance = 5},
         rotor = {optimal = 58, min = 45, max = 70, tolerance = 6},
-        feeder = {optimal = 45, min = 30, max = 60, tolerance = 8},
+        concave = {optimal = 20, min = 10, max = 35, tolerance = 6},   -- tight: ~10mm
     },
 
-    -- Mustard / Buckwheat - Drum speed 480-520 = 500 = 33%, Fan 550 = 28%, Upper 10-25 = 17mm = 57%, Lower 8mm = 32%
+    -- Mustard / Buckwheat - Drum speed 480-520 = 500 = 33%, Fan 550 = 28%, Chaffer 17mm = 57%, Sieve 8mm = 32%
     mustard = {
         fan = {optimal = 28, min = 15, max = 45, tolerance = 6},
         upperSieve = {optimal = 57, min = 40, max = 75, tolerance = 5},
         lowerSieve = {optimal = 32, min = 20, max = 45, tolerance = 5},
         rotor = {optimal = 33, min = 20, max = 50, tolerance = 6},
-        feeder = {optimal = 40, min = 25, max = 55, tolerance = 8},
+        concave = {optimal = 20, min = 10, max = 35, tolerance = 6},
     },
 
-    -- Clover - MAXIMUM Drum speed 1100 = 100%, MAX fan 1200 = 100%, Upper 3-5mm = 4mm = 13%, Lower 2mm = 8%
+    -- Clover - MAXIMUM Drum speed 1100 = 100%, MAX fan 1200 = 100%, Chaffer 4mm = 13%, Sieve 2mm = 8%
     clover = {
         fan = {optimal = 100, min = 85, max = 100, tolerance = 5},
         upperSieve = {optimal = 13, min = 5, max = 25, tolerance = 5},
         lowerSieve = {optimal = 8, min = 0, max = 20, tolerance = 5},
         rotor = {optimal = 100, min = 85, max = 100, tolerance = 5},
-        feeder = {optimal = 50, min = 35, max = 65, tolerance = 8},
+        concave = {optimal = 10, min = 0, max = 25, tolerance = 5},    -- very tight: ~5mm
     },
 
-    -- Grass Seed - MAX Drum (Fine) 920 = 80%, Fan 650 = 39%, Upper 5mm = 17%, Lower 3mm = 12%
+    -- Grass Seed - MAX Drum (Fine) 920 = 80%, Fan 650 = 39%, Chaffer 5mm = 17%, Sieve 3mm = 12%
     grass_seed = {
         fan = {optimal = 39, min = 25, max = 55, tolerance = 7},
         upperSieve = {optimal = 17, min = 5, max = 30, tolerance = 5},
         lowerSieve = {optimal = 12, min = 0, max = 25, tolerance = 5},
         rotor = {optimal = 80, min = 65, max = 95, tolerance = 6},
-        feeder = {optimal = 45, min = 30, max = 60, tolerance = 8},
+        concave = {optimal = 15, min = 5, max = 30, tolerance = 5},
+    },
+
+    -- ============================
+    -- COTTON HARVESTER TEMPLATES
+    -- ============================
+    cotton_picker = {
+        fan = {optimal = 80, min = 60, max = 100, tolerance = 10},
+        rotor = {optimal = 70, min = 50, max = 90, tolerance = 10},
+        feeder = {optimal = 60, min = 40, max = 80, tolerance = 10},
     },
 }
 -- EN: Active parameters per machine type. Defines which parameter sliders appear in the calibration GUI.
@@ -286,7 +293,7 @@ local templates = {
 
 ---Active parameters per machine type (defines which sliders appear in GUI)
 CombineSettingsDatabase.machineParams = {
-    grain   = { "fan", "rotor", "upperSieve", "lowerSieve", "feeder" },
+    grain   = { "fan", "rotor", "upperSieve", "lowerSieve", "concave" },  -- concave = 0-50mm clearance
     forage  = { "fan", "rotor", "feeder" },
     root    = { "fan", "rotor", "feeder" },
     cotton  = { "fan", "rotor", "feeder" },
@@ -300,7 +307,7 @@ CombineSettingsDatabase.machineParamLabels = {
         rotor      = "rhm_ui_rotor_speed",
         upperSieve = "rhm_ui_upper_sieve",
         lowerSieve = "rhm_ui_lower_sieve",
-        feeder     = "rhm_ui_feeder_speed",
+        concave    = "rhm_ui_concave_gap",  -- 0-50mm clearance
     },
     forage = {
         fan    = "rhm_ui_forage_fan",

--- a/src/gui/CombineCalibrationGUI.lua
+++ b/src/gui/CombineCalibrationGUI.lua
@@ -1,17 +1,43 @@
 -- EN: Interactive visual calibration GUI for combine harvester settings.
---     Renders as an always-on overlay panel with sliders ([-]/[+] buttons and mouse wheel)
+--     Renders as an always-on overlay panel with [-]/[+] buttons and mouse wheel
 --     for each active parameter (fan, rotor, sieves, feeder) based on machine type.
 --     Shows real-time color-coded loss and speed penalty preview from CombineSettingsDatabase.
+--     Parameters grouped by function: SEPARATION / CLEANING / PERFORMANCE.
+--     Each parameter row shows: label | physical value | status hint | progress bar | [-][+] buttons.
 --     Supports NEXAT modular systems by searching the vehicle hierarchy for spec_rhm_Combine.
 --     Blocks camera rotation and zoom while open; restores them on close.
 -- UA: Інтерактивний візуальний GUI калібрування для налаштувань зернозбирального комбайна.
---     Відображається як постійна накладка з повзунками (кнопки [-]/[+] та колесо миші)
+--     Відображається як постійна накладка з кнопками [-]/[+] та колесом миші
 --     для кожного активного параметра (вентилятор, ротор, решета, подача) залежно від типу машини.
 --     Показує попередній перегляд штрафів за втрати та швидкість у режимі реального часу з CombineSettingsDatabase.
+--     Параметри згруповані за функцією: SEPARATION / CLEANING / PERFORMANCE.
+--     Кожен рядок параметра показує: мітка | фізичне значення | статус | прогрес-бар | кнопки [-][+].
 --     Підтримує модульні системи NEXAT, шукаючи spec_rhm_Combine в ієрархії транспорту.
 --     Блокує обертання та масштабування камери при відкритті; відновлює при закритті.
 CombineCalibrationGUI = {}
 local CombineCalibrationGUI_mt = Class(CombineCalibrationGUI)
+
+-- EN: Parameter section grouping — defines which parameters belong to which section label.
+--     Parameters not listed here that come from getParamsForMachineType fall through to a
+--     catch-all "OTHER" render before the Performance/TargetEngineLoad section.
+-- UA: Групування параметрів по секціях — визначає які параметри до якої секції належать.
+--     Параметри яких немає у цьому списку що приходять з getParamsForMachineType потрапляють
+--     у загальну секцію "OTHER" перед секцією Performance/TargetEngineLoad.
+local PARAM_SECTION_MAP = {
+    fan        = "CLEANING",
+    rotor      = "SEPARATION",
+    feeder     = "SEPARATION",   -- forage/root/cotton feed roll
+    concave    = "SEPARATION",   -- grain concave gap (0-50mm)
+    upperSieve = "CLEANING",
+    lowerSieve = "CLEANING",
+}
+
+-- EN: Ordered section definitions for the draw loop.
+-- UA: Впорядковані визначення секцій для циклу малювання.
+local SECTIONS_ORDERED = {
+    { key = "SEPARATION", label = "rhm_ui_section_separation" },
+    { key = "CLEANING",   label = "rhm_ui_section_cleaning"   },
+}
 
 -- EN: Creates a new GUI instance. Initializes UI layout constants, color palette,
 --     button registry, scroll debouncing, and the persistent overlay object.
@@ -22,71 +48,73 @@ function CombineCalibrationGUI.new(modDirectory)
     self.modDirectory = modDirectory
     self.isOpen = false
     self.isCursorActive = false
-    self.debug = true -- EN: Enable diagnostic logging / UA: Увімкнути діагностичне логування
-    
-    -- EN: UI layout configuration: position, size, margins, typography, and color palette.
-    -- UA: Конфігурація розмітки UI: позиція, розмір, відступи, типографіка та кольорова палітра.
+    self.debug = true
+
+    -- EN: UI layout — industrial dark theme with amber accents.
+    -- UA: Розмітка UI — індустріальна темна тема з бурштиновими акцентами.
     self.ui = {
-        x = 0.68, y = 0.45, -- EN: Position (right side of screen) / UA: Позиція (права сторона екрану)
-        w = 0.30, h = 0.45, -- EN: Width and height (normalized screen units) / UA: Ширина та висота (нормалізовані одиниці)
-        margin = 0.01,
-        headerHeight = 0.04,
-        lineHeight = 0.035,
-        fontSize = 0.014,
-        titleSize = 0.020,
-        buttonW = 0.025,
-        buttonH = 0.025,
-        
-        -- EN: Color palette for all GUI elements.
-        -- UA: Кольорова палітра для всіх елементів GUI.
+        x = 0.68, y = 0.45,
+        w = 0.30, h = 0.45,
+        margin      = 0.010,
+        headerHeight = 0.038,
+        statsHeight  = 0.026,  -- EN: Live stats bar height / UA: Висота смуги живої статистики
+        lineHeight   = 0.038,  -- EN: Increased from 0.035 to fit progress bar / UA: Збільшено з 0.035 для прогрес-бару
+        sectionGap   = 0.022,  -- EN: Height of each section header row / UA: Висота рядка заголовку секції
+        fontSize    = 0.013,
+        titleSize   = 0.018,
+        sectionSize = 0.012,   -- EN: Section label font size / UA: Розмір шрифту мітки секції
+        statusSize  = 0.011,   -- EN: Status hint font size / UA: Розмір шрифту підказки статусу
+        buttonW     = 0.026,
+        buttonH     = 0.022,
+
+        -- EN: Industrial dark color palette.
+        -- UA: Індустріальна темна кольорова палітра.
         colors = {
-            bg = {0.05, 0.05, 0.05, 0.9},
-            header = {0.1, 0.1, 0.1, 0.95},
-            text = {1, 1, 1, 1},
-            textDim = {0.7, 0.7, 0.7, 1},
-            accent = {0.2, 0.6, 1.0, 1},          -- EN: Blue highlight / UA: Синій акцент
-            warning = {1.0, 0.6, 0.2, 1},          -- EN: Orange warning / UA: Помаранчеве попередження
-            error = {0.9, 0.2, 0.2, 1},             -- EN: Red error / UA: Червона помилка
-            success = {0.2, 0.8, 0.2, 1},           -- EN: Green optimal / UA: Зелений оптимум
-            button = {0.2, 0.2, 0.2, 1},
-            buttonHover = {0.3, 0.4, 0.5, 1},      -- EN: Blue-tinted hover / UA: Синюватий колір при наведенні
-            buttonActive = {0.4, 0.4, 0.4, 1},
-            paramRowHover = {0.15, 0.15, 0.15, 0.8} -- EN: Subtle row highlight / UA: М'яке підсвічування рядка
+            bg            = {0.04, 0.05, 0.03, 0.96},
+            header        = {0.09, 0.07, 0.03, 1.00},
+            headerAccent  = {0.83, 0.54, 0.04, 1.00},  -- EN: Amber accent line / UA: Бурштинова акцентна лінія
+            statsBg       = {0.00, 0.00, 0.00, 0.30},
+            sectionLine   = {1.00, 1.00, 1.00, 0.08},
+            separator     = {1.00, 1.00, 1.00, 0.06},
+            paramRowHover = {1.00, 1.00, 1.00, 0.03},
+            barBg         = {1.00, 1.00, 1.00, 0.07},
+            barOptimal    = {1.00, 1.00, 1.00, 0.42},
+            text          = {0.91, 0.87, 0.78, 1.00},
+            textDim       = {0.70, 0.68, 0.65, 1.00},
+            accent        = {0.83, 0.54, 0.04, 1.00},
+            accentDim     = {0.83, 0.54, 0.04, 0.14},
+            success       = {0.24, 0.72, 0.47, 1.00},
+            warning       = {0.91, 0.78, 0.25, 1.00},
+            error         = {0.89, 0.29, 0.29, 1.00},
+            teal          = {0.60, 1.00, 0.80, 1.00},
+            button        = {0.15, 0.15, 0.13, 0.95},
+            buttonHover   = {0.22, 0.22, 0.20, 1.00},
+            buttonAuto    = {0.05, 0.18, 0.09, 1.00},
+            buttonReset   = {0.20, 0.08, 0.03, 1.00},
+            buttonSave    = {0.06, 0.12, 0.04, 1.00},
         }
     }
-    
-    -- EN: Interaction state: active vehicle, hover tracking, mouse position.
-    -- UA: Стан взаємодії: активний транспорт, відстеження наведення, позиція миші.
+
     self.activeVehicle = nil
     self.hoveredElement = nil
     self.mouseX = 0
     self.mouseY = 0
-    self.hoveredParameter = nil  -- EN: Which parameter row the mouse is over / UA: Над яким рядком параметра знаходиться миша
-    
-    -- EN: Saved camera state — restored exactly on close, not globally reset.
-    -- UA: Збережений стан камери — відновлюється точно при закритті, а не скидається глобально.
+    self.hoveredParameter = nil
+
     self.savedCameraRotatableInfo = {}
     self.savedCameraZoomInfo = {}
-    
-    -- EN: Scroll debouncing prevents scroll events from firing more than once per scrollDelayMs.
-    -- UA: Захист від дребезгу прокрутки запобігає спрацюванню більше ніж раз за scrollDelayMs.
+
     self.lastScrollTimeStamp = 0
     self.scrollDelayMs = 100
-    
-    -- EN: Button registry rebuilt every frame in draw(). Used for click hit-testing.
-    -- UA: Реєстр кнопок перебудовується кожен кадр у draw(). Використовується для перевірки кліків.
-    self.buttons = {} 
-    
-    -- EN: Persistent overlay object — reused every frame for drawing all colored rectangles.
-    -- UA: Постійний об'єкт оверлею — перевикористовується кожен кадр для малювання всіх кольорових прямокутників.
+
+    self.buttons = {}
+
     local bgTexture = self.modDirectory .. "textures/hud_background.dds"
     self.overlay = Overlay.new(bgTexture, 0, 0, 1, 1)
-    
+
     return self
 end
 
--- EN: Releases the overlay GPU resource.
--- UA: Звільняє ресурс GPU оверлею.
 function CombineCalibrationGUI:delete()
     if self.overlay then
         self.overlay:delete()
@@ -94,8 +122,6 @@ function CombineCalibrationGUI:delete()
     end
 end
 
--- EN: Toggles the GUI open if closed (for the given vehicle) or closes if open.
--- UA: Перемикає GUI відкрити/закрити — відкриває для заданого транспортного засобу або закриває.
 function CombineCalibrationGUI:toggle(vehicle)
     if self.isOpen then
         self:close()
@@ -105,22 +131,16 @@ function CombineCalibrationGUI:toggle(vehicle)
 end
 
 -- EN: Opens the calibration GUI for a vehicle.
---     For modular systems (NEXAT), searches the entire vehicle hierarchy for spec_rhm_Combine
---     because the player may be sitting in a cab that doesn't have the spec itself.
---     Blocks camera rotation and zoom to prevent accidental camera movement while adjusting sliders.
+--     For modular systems (NEXAT), searches the entire vehicle hierarchy for spec_rhm_Combine.
+--     Blocks camera rotation and zoom to prevent accidental camera movement.
 -- UA: Відкриває GUI калібрування для транспортного засобу.
---     Для модульних систем (NEXAT), шукає в усій ієрархії транспорту spec_rhm_Combine,
---     оскільки гравець може сидіти у кабіні без самої специфікації.
---     Блокує обертання та масштابування камери для запобігання випадкового руху під час регулювання.
+--     Для модульних систем (NEXAT), шукає в усій ієрархії транспорту spec_rhm_Combine.
+--     Блокує обертання та масштабування камери для запобігання випадкового руху.
 function CombineCalibrationGUI:open(vehicle)
     if self.isOpen then return end
-    
-    -- EN: NEXAT FIX: find the vehicle with spec_rhm_Combine in the full hierarchy.
-    -- UA: NEXAT FIX: шукаємо транспортний засіб з spec_rhm_Combine у повній ієрархії.
+
     local combineVehicle = vehicle
     if vehicle and not vehicle.spec_rhm_Combine then
-        -- EN: Recursive hierarchy search — visits parent, attacher, and all implements.
-        -- UA: Рекурсивний пошук в ієрархії — відвідує батька, причеп та всі реалізації.
         local function findCombine(v, visited)
             if not v or visited[v] then return nil end
             visited[v] = true
@@ -152,64 +172,45 @@ function CombineCalibrationGUI:open(vehicle)
             return
         end
     end
-    
+
     self.isOpen = true
-    
-    -- EN: Enable mouse cursor so the player can interact with the GUI.
-    -- UA: Вмикаємо курсор миші щоб гравець міг взаємодіяти з GUI.
     g_inputBinding:setShowMouseCursor(true)
     self.isCursorActive = true
-    
-    -- EN: Block camera rotation AND zoom on the vehicle the player is ACTUALLY sitting in.
-    --     (For NEXAT, this is the cab vehicle, not the combine module.)
-    -- UA: Блокуємо обертання і масштаб камери на транспортному засобі в якому сидить гравець.
-    --     (Для NEXAT — це кабіна, а не модуль комбайна.)
+
     local cv = nil
     if g_realisticHarvestManager then
         cv = g_realisticHarvestManager:getControlledVehicle()
     else
         cv = g_currentMission.controlledVehicle
     end
-    
+
     if cv and cv.spec_enterable then
         for _, camera in pairs(cv.spec_enterable.cameras) do
             self.savedCameraRotatableInfo[camera] = camera.isRotatable
             self.savedCameraZoomInfo[camera] = camera.allowZoom
             camera.isRotatable = false
             camera.allowTranslation = false
-            camera.allowZoom = false  -- EN: Block scroll-wheel zoom / UA: Блокуємо масштабування колесом
+            camera.allowZoom = false
         end
     end
-    
-    -- EN: Store both the combine vehicle (from hierarchy) and the vehicle the player controls.
-    -- UA: Зберігаємо як комбайн (з ієрархії), так і транспорт яким керує гравець.
+
     self.activeVehicle = combineVehicle
     self.controllerVehicle = cv or vehicle or combineVehicle
 end
 
--- EN: Closes the calibration GUI. Restores camera rotation and zoom to their pre-open state.
---     If HUD cursor mode is still active (from RealisticHarvestManager:toggleCursor),
---     the cursor is kept visible but camera rotation is re-blocked from the HUD drag state.
--- UA: Закриває GUI калібрування. Відновлює обертання та масштаб камери до стану до відкриття.
---     Якщо режим курсора HUD ще активний (з RealisticHarvestManager:toggleCursor),
---     курсор залишається видимим але обертання камери знову блокується для стану перетягування HUD.
+-- EN: Closes the calibration GUI. Restores camera rotation and zoom.
+-- UA: Закриває GUI калібрування. Відновлює обертання та масштаб камери.
 function CombineCalibrationGUI:close()
     if not self.isOpen then return end
-    
+
     self.isOpen = false
     self.isCursorActive = false
-    
-    -- EN: Use the controller vehicle (cab) for camera restoration, not the combine module.
-    -- UA: Використовуємо транспорт з кабіною для відновлення камери, а не модуль комбайна.
+
     local vehicle = self.controllerVehicle
-    
-    -- EN: Check if HUD cursor mode is still active (from RHM Manager toggleCursor).
-    -- UA: Перевіряємо чи активний режим курсора HUD (з toggleCursor менеджера RHM).
+
     local hudCursorActive = g_realisticHarvestManager and g_realisticHarvestManager.isCursorVisible
     g_inputBinding:setShowMouseCursor(hudCursorActive or false)
-    
-    -- EN: Restore camera rotation and zoom from saved state.
-    -- UA: Відновлюємо обертання та масштаб камери зі збереженого стану.
+
     if vehicle and vehicle.spec_enterable then
         for _, camera in pairs(vehicle.spec_enterable.cameras) do
             local savedRotatable = self.savedCameraRotatableInfo[camera]
@@ -221,29 +222,23 @@ function CombineCalibrationGUI:close()
         self.savedCameraRotatableInfo = {}
         self.savedCameraZoomInfo = {}
     end
-    
-    -- EN: If HUD cursor was active, re-block camera rotation (camera state managed by Manager, not GUI).
-    -- UA: Якщо курсор HUD був активний, знову блокуємо обертання камери (стан управляється Менеджером, не GUI).
+
     if hudCursorActive and vehicle and vehicle.spec_enterable then
         RHMInputUtil.setCameraRotation(vehicle, false, g_realisticHarvestManager.savedCameraRotatableInfo)
     end
 end
 
--- EN: Cycles to the previous (-1) or next (+1) crop in the machine-type-filtered crop list.
---     Calls CombineMemory:switchCrop which handles settings handover and network sync.
--- UA: Перемикає на попередню (-1) або наступну (+1) культуру у відфільтрованому за типом машини списку.
---     Викликає CombineMemory:switchCrop який обробляє передачу налаштувань та мережеву синхронізацію.
+-- EN: Cycles to the previous (-1) or next (+1) crop in the machine-type-filtered list.
+-- UA: Перемикає на попередню (-1) або наступну (+1) культуру у відфільтрованому списку.
 function CombineCalibrationGUI:cycleCrop(direction)
     local spec = self.activeVehicle.spec_rhm_Combine
     local machineType = spec.machineType or "grain"
-    -- EN: Only show crops relevant to this machine type in the cycle.
-    -- UA: У циклі показуємо лише культури відповідного типу машини.
     local crops = CombineSettingsDatabase:getCropNamesForMachineType(machineType)
     if #crops == 0 then return end
-    
+
     local current = spec.combineMemory.currentCrop
     local index = 1
-    
+
     if current then
         for i, name in ipairs(crops) do
             if name == current then
@@ -252,54 +247,28 @@ function CombineCalibrationGUI:cycleCrop(direction)
             end
         end
     end
-    
+
     index = index + direction
     if index > #crops then index = 1 end
     if index < 1 then index = #crops end
-    
+
     local newCrop = crops[index]
     spec.combineMemory:switchCrop(newCrop)
 end
 
--- EN: Handles mouse events. Intercepts scroll wheel events to prevent camera zoom while GUI is open.
---     Left-click is handled separately in the full mouseEvent method below.
--- UA: Обробляє події миші. Перехоплює події колеса прокрутки щоб запобігти масштабуванню камери поки GUI відкритий.
---     Лівий клік обробляється окремо у повному методі mouseEvent нижче.
-function CombineCalibrationGUI:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
-    if not self.isOpen then return false end
-    
-    -- EN: Consume scroll wheel events entirely to block camera zoom (GIANTS engine: button 4=up, 5=down).
-    -- UA: Повністю з'їдаємо події колеса прокрутки для блокування масштабування камери (button 4=вгору, 5=вниз).
-    if button == Input.MOUSE_BUTTON_WHEEL_UP or button == Input.MOUSE_BUTTON_WHEEL_DOWN then
-        return true
-    end
-    
-    return false
-end
-
 -- EN: Called every frame while open. Auto-closes if the player exits the vehicle.
---     Handles both standard vehicles and NEXAT modular systems (root vehicle matching).
 -- UA: Викликається кожен кадр поки відкритий. Автоматично закриває якщо гравець виходить з транспорту.
---     Обробляє як стандартні транспортні засоби, так і модульні системи NEXAT (перевірка кореневого транспорту).
 function CombineCalibrationGUI:update(dt)
     if not self.isOpen then return end
-    
-    -- EN: Close if the active vehicle was unloaded or removed from the mission.
-    -- UA: Закриваємо якщо активний транспортний засіб вивантажено або видалено з місії.
+
     if not self.activeVehicle then
-         self:close()
-         return
+        self:close()
+        return
     end
-    
-    -- EN: Determine if the player is still in their vehicle.
-    --     For NEXAT: controllerVehicle = cab, activeVehicle = combine module.
-    --     Match by direct equality or by shared rootVehicle to support modular trains.
-    -- UA: Визначаємо чи гравець все ще знаходиться у своєму транспортному засобі.
-    --     Для NEXAT: controllerVehicle = кабіна, activeVehicle = модуль комбайна.
-    --     Порівнюємо напряму або за спільним rootVehicle для підтримки модульних потягів.
+
     local vehicleToCheck = self.controllerVehicle or self.activeVehicle
     local isEntered = false
-    
+
     if vehicleToCheck then
         local cv = nil
         if g_realisticHarvestManager then
@@ -307,13 +276,11 @@ function CombineCalibrationGUI:update(dt)
         else
             cv = g_currentMission.controlledVehicle
         end
-        
+
         if cv then
             if cv == vehicleToCheck then
                 isEntered = true
             else
-                -- EN: Match by shared root vehicle (NEXAT cab vs combine module).
-                -- UA: Порівнюємо за спільним кореневим транспортом (кабіна NEXAT vs модуль комбайна).
                 local rootA = cv.rootVehicle or cv
                 local rootB = vehicleToCheck.rootVehicle or vehicleToCheck
                 if rootA == rootB then
@@ -321,9 +288,7 @@ function CombineCalibrationGUI:update(dt)
                 end
             end
         end
-        
-        -- EN: Fallback for AI-controlled or directly entered vehicles.
-        -- UA: Резервна перевірка для транспорту під управлінням AI або прямого входу.
+
         if not isEntered and vehicleToCheck.getIsEntered then
             isEntered = vehicleToCheck:getIsEntered()
         end
@@ -332,79 +297,237 @@ function CombineCalibrationGUI:update(dt)
     if not isEntered then
         print("RHM: [GUI] Closing due to isEntered=false."
             .. " RHM_cv=" .. tostring(g_realisticHarvestManager and g_realisticHarvestManager:getControlledVehicle())
-            .. " vToCheck=" .. tostring(vehicleToCheck) 
+            .. " vToCheck=" .. tostring(vehicleToCheck)
             .. " (root=" .. tostring(vehicleToCheck and (vehicleToCheck.rootVehicle or vehicleToCheck)) .. ")")
         self:close()
     end
 end
 
--- EN: Main draw function. Renders the calibration panel with header, crop selector,
---     mode buttons (AUTO/LOAD PRESET), parameter rows, loss/speed preview, and profile buttons.
---     Also processes mouse wheel scroll over parameter rows at the end of the frame.
--- UA: Головна функція малювання. Відображає панель калібрування із заголовком, вибором культури,
---     кнопками режиму (AUTO/LOAD PRESET), рядками параметрів, попереднім переглядом втрат/швидкості та кнопками профілю.
---     Також обробляє прокрутку колесом миші над рядками параметрів в кінці кадру.
+-- EN: Main draw function. Renders the redesigned calibration panel:
+--       Header (amber title + close hint)
+--       Stats bar (live: engine load | speed | loss preview)
+--       Crop selector (< CROPNAME >) + AUTO button
+--       Grouped parameter rows (SEPARATION / CLEANING / PERFORMANCE)
+--         each row: label | value | status | progress bar | [-] [+]
+--       Save Profile | Reset Default buttons
+--       Close hint
+-- UA: Головна функція малювання. Відображає перероблену панель калібрування:
+--       Заголовок (бурштиновий заголовок + підказка закриття)
+--       Смуга статистики (жива: навантаження двигуна | швидкість | попередній перегляд втрат)
+--       Вибір культури (< НАЗВА >) + кнопка AUTO
+--       Згруповані рядки параметрів (SEPARATION / CLEANING / PERFORMANCE)
+--         кожен рядок: мітка | значення | статус | прогрес-бар | [-] [+]
+--       Кнопки Save Profile | Reset Default
+--       Підказка закриття
 function CombineCalibrationGUI:draw()
     if not self.isOpen then return end
-    if not (g_currentMission and g_currentMission.hud) then 
+    if not (g_currentMission and g_currentMission.hud) then
         if self.debug then print("RHM: [GUI] draw() abort: no g_currentMission.hud") end
-        return 
+        return
     end
-    
-    -- EN: Clear button registry at start of each frame — rebuilt during draw.
-    -- UA: Очищаємо реєстр кнопок на початку кожного кадру — перебудовується під час малювання.
+
     self.buttons = {}
     self.hoveredParameter = nil
-    
+
     local ui = self.ui
+    local spec = self.activeVehicle and self.activeVehicle.spec_rhm_Combine
+
+    -- EN: Dynamic height: accounts for header, stats bar, crop row, section headers,
+    --     param rows, action buttons, close hint.
+    -- UA: Динамічна висота: враховує заголовок, смугу статистики, рядок культури,
+    --     заголовки секцій, рядки параметрів, кнопки дій, підказку закриття.
+    if spec and spec.combineMemory then
+        local machineType = spec.machineType or "grain"
+        local activeParams = CombineSettingsDatabase:getParamsForMachineType(machineType)
+        local numParams = #activeParams + 1  -- +1 for targetEngineLoad
+
+        -- EN: Count how many sections will be shown (for height calculation).
+        -- UA: Рахуємо скільки секцій буде показано (для розрахунку висоти).
+        local sectionsShown = 0
+        for _, section in ipairs(SECTIONS_ORDERED) do
+            for _, p in ipairs(activeParams) do
+                if PARAM_SECTION_MAP[p] == section.key then
+                    sectionsShown = sectionsShown + 1
+                    break
+                end
+            end
+        end
+        sectionsShown = sectionsShown + 1  -- +1 for PERFORMANCE section
+
+        -- EN: Harvest Report section height (tier 1+): section header + 4 stat rows + grade row + reset button + separators.
+        -- UA: Висота секції звіту про жнива (рівень 1+): заголовок + 4 рядки + оцінка + кнопка + розділювачі.
+        local upgradeLevel = spec.combineMemory.upgradeLevel or 0
+        local harvestReportH = 0
+        if upgradeLevel >= 1 then
+            harvestReportH = ui.sectionGap                  -- section header bar
+                           + ui.lineHeight * 0.75 * 4       -- 4 stat rows
+                           + ui.lineHeight * 0.80           -- grade row
+                           + ui.lineHeight * 0.85           -- reset button
+                           + ui.margin * 1.0                -- separator margins
+        end
+
+        local dynamicH = ui.headerHeight
+                       + ui.statsHeight
+                       + ui.lineHeight        -- crop row
+                       + ui.margin * 0.5
+                       + (sectionsShown * ui.sectionGap)
+                       + (numParams * ui.lineHeight)
+                       + ui.lineHeight * 2.2  -- action buttons
+                       + ui.lineHeight * 0.8  -- close hint
+                       + ui.sectionGap        -- UPGRADES section header
+                       + ui.lineHeight * 1.4  -- upgrade status + button
+                       + harvestReportH
+                       + ui.margin * 4
+
+        local targetTop = 0.91
+        ui.h = dynamicH
+        ui.y = targetTop - dynamicH
+    else
+        ui.h = 0.50
+        ui.y = 0.40
+    end
+
     local x, y = ui.x, ui.y
     local w, h = ui.w, ui.h
-    
-    -- EN: Draw background panel and header strip.
-    -- UA: Малюємо фонову панель і смугу заголовку.
+
+    -- ── Background panel ────────────────────────────────────────────────────
     self:drawRect(x, y, w, h, ui.colors.bg)
-    self:drawRect(x, y + h - ui.headerHeight, w, ui.headerHeight, ui.colors.header)
+
+    -- ── Header strip ────────────────────────────────────────────────────────
+    local headerY = y + h - ui.headerHeight
+    self:drawRect(x, headerY, w, ui.headerHeight, ui.colors.header)
+
+    -- EN: Amber accent line at bottom of header (visual separator).
+    -- UA: Бурштинова акцентна лінія знизу заголовку (візуальний розділювач).
+    self:drawRect(x, headerY, w, 0.0015, ui.colors.headerAccent)
+
     setTextBold(true)
     setTextAlignment(RenderText.ALIGN_CENTER)
-    setTextColor(unpack(ui.colors.text))
-    renderText(x + w/2, y + h - ui.headerHeight + 0.01, ui.titleSize, g_i18n:getText("rhm_gui_title"))
-    
-    local cy = y + h - ui.headerHeight - ui.margin - ui.lineHeight
-    
+    setTextColor(unpack(ui.colors.accent))
+    renderText(x + w / 2, headerY + ui.headerHeight * 0.35, ui.titleSize, g_i18n:getText("rhm_gui_title"))
+    setTextBold(false)
+
+    -- EN: Close shortcut right-aligned in header.
+    -- UA: Комбінація клавіш закриття по правому краю заголовку.
+    setTextAlignment(RenderText.ALIGN_RIGHT)
+    setTextColor(unpack(ui.colors.textDim))
+    renderText(x + w - ui.margin, headerY + ui.headerHeight * 0.35, ui.fontSize * 0.80, g_i18n:getText("rhm_gui_close_hint"))
+
+    local cy = headerY - ui.margin * 0.5
+
+    -- EN: Early exit if vehicle/spec not ready.
+    -- UA: Ранній вихід якщо транспорт/специфікація не готові.
     if not self.activeVehicle then
-        if self.debug then print("RHM: [GUI] draw() rendering 'No Combine Selected'") end
         setTextAlignment(RenderText.ALIGN_CENTER)
-        renderText(x + w/2, cy, ui.fontSize, g_i18n:getText("rhm_gui_no_combine"))
+        setTextColor(unpack(ui.colors.textDim))
+        renderText(x + w / 2, cy - ui.lineHeight, ui.fontSize, g_i18n:getText("rhm_gui_no_combine"))
+        self:_resetTextState()
         return
     end
-    
-    local spec = self.activeVehicle.spec_rhm_Combine
-    
+
+    spec = self.activeVehicle.spec_rhm_Combine
     if not spec or not spec.combineMemory then
-        if self.debug then print("RHM: [GUI] draw() rendering 'Combine not initialized' | spec="..tostring(spec~=nil).." memory="..tostring(spec and spec.combineMemory~=nil)) end
         setTextAlignment(RenderText.ALIGN_CENTER)
-        renderText(x + w/2, cy, ui.fontSize, g_i18n:getText("rhm_gui_not_init"))
+        setTextColor(unpack(ui.colors.textDim))
+        renderText(x + w / 2, cy - ui.lineHeight, ui.fontSize, g_i18n:getText("rhm_gui_not_init"))
+        self:_resetTextState()
         return
     end
-    
+
     local memory = spec.combineMemory
-    
-    -- EN: Crop selector row with prev/next buttons and localized crop name.
-    -- UA: Рядок вибору культури з кнопками попередньої/наступної та локалізованою назвою культури.
+    local machineType = spec.machineType or "grain"
+
+    -- ── Stats bar ───────────────────────────────────────────────────────────
+    -- EN: Live stats: engine load | speed penalty preview | loss preview.
+    -- UA: Жива статистика: навантаження двигуна | попередній перегляд штрафу швидкості | попередній перегляд втрат.
+    cy = cy - ui.statsHeight
+    self:drawRect(x, cy, w, ui.statsHeight, ui.colors.statsBg)
+
+    local load = (spec.loadCalculator and spec.loadCalculator.engineLoad or 0) * 100
+    local effPenalty = 0
+    local lossPenalty = 0
+    if memory.currentCrop then
+        effPenalty, lossPenalty, _ = memory:checkSettingsForCrop(memory.currentCrop)
+    end
+
+    -- EN: Engine load — colored by threshold.
+    -- UA: Навантаження двигуна — кольоровий за порогом.
+    local loadColor = load > 95 and ui.colors.error or (load > 80 and ui.colors.warning or ui.colors.success)
+    setTextBold(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
-    renderText(x + ui.margin, cy + 0.005, ui.fontSize, g_i18n:getText("rhm_gui_crop"))
-    
-    local cropX = x + ui.margin + 0.05
-    
-    self:drawButton(cropX, cy, 0.025, 0.035, "<", function()
-        self:cycleCrop(-1)
-    end)
-    
-    -- EN: Localize the crop name via FillType manager, with l10n key fallback.
-    -- UA: Локалізуємо назву культури через FillType менеджер, з резервним l10n ключем.
+    setTextColor(unpack(ui.colors.textDim))
+    renderText(x + ui.margin, cy + 0.008, ui.statusSize, "Load")
+    setTextColor(unpack(loadColor))
+    renderText(x + ui.margin + 0.028, cy + 0.008, ui.fontSize, string.format("%.0f%%", load))
+
+    -- EN: Speed/loss preview — visible only with Machine Monitor upgrade (tier 2+).
+    --     Without upgrade, show a subtle "upgrade required" hint.
+    -- UA: Попередній перегляд швидкості/втрат — тільки з апгрейдом Монітор (рівень 2+).
+    local upgradeLevel = memory.upgradeLevel or 0
+    local hasMonitor = upgradeLevel >= 2
+
+    if hasMonitor then
+        local speedStr
+        if effPenalty < 0 then
+            speedStr = string.format("+%.1f%%", math.abs(effPenalty) * 5.0)
+        else
+            speedStr = string.format("-%.1f%%", effPenalty)
+        end
+        local lossStr
+        if lossPenalty <= 0 then
+            lossStr = "0.0%"
+        else
+            lossStr = string.format("+%.1f%%", lossPenalty)
+        end
+        local statsTextColor = ui.colors.text
+        if lossPenalty > 0.5 or effPenalty > 0.5 then
+            statsTextColor = ui.colors.error
+        elseif effPenalty < -0.1 and lossPenalty <= 0.5 then
+            statsTextColor = ui.colors.success
+        end
+        setTextAlignment(RenderText.ALIGN_RIGHT)
+        setTextColor(unpack(statsTextColor))
+        renderText(x + w - ui.margin, cy + 0.008, ui.fontSize, "Spd " .. speedStr .. "  Loss " .. lossStr)
+
+        -- EN: Dynamic yield trend hint (Tier 2 Machine Monitor).
+        --     Shows a proactive hint when the combine is not utilizing capacity optimally.
+        -- UA: Підказка тренду врожайності (рівень 2 Machine Monitor).
+        local lc = spec.loadCalculator
+        if lc then
+            local loadPct = (lc.engineLoad or 0) * 100
+            local hdrLoss = lc.headerLoss or 0
+            local trendHint = nil
+            if loadPct > 100 and (lc.upgradeLevel or 0) < 3 then
+                -- EN: No Speed Control tier yet — manual warning.
+                trendHint = "Load high — slow down!"
+            elseif hdrLoss > 2.0 then
+                trendHint = string.format("Hdr loss %.1f%% — reduce speed", hdrLoss)
+            elseif lc.isPlugged then
+                trendHint = "ROTOR PLUGGED — reverse/slow"
+            elseif lossPenalty > 3.0 then
+                trendHint = "Check settings for crop"
+            elseif loadPct < 55 and loadPct > 5 then
+                trendHint = "Under-utilized — increase speed"
+            end
+            if trendHint then
+                setTextAlignment(RenderText.ALIGN_CENTER)
+                setTextColor(0.91, 0.78, 0.25, 0.90)
+                renderText(x + w * 0.5, cy - ui.statusSize * 0.5, ui.statusSize, trendHint)
+            end
+        end
+    else
+        setTextAlignment(RenderText.ALIGN_RIGHT)
+        setTextColor(0.83, 0.54, 0.04, 0.55)
+        renderText(x + w - ui.margin, cy + 0.008, ui.statusSize, "Upgrade required for hints")
+    end
+
+    cy = cy - ui.margin * 0.4
+
+    -- ── Crop selector + AUTO button ─────────────────────────────────────────
+    cy = cy - ui.lineHeight
+
     local function getLocalizedCropName(rawName)
         if not rawName then return g_i18n:getText("rhm_gui_none") end
-        
         local displayName = rawName
         local fillTypeIndex = g_fillTypeManager:getFillTypeIndexByName(rawName)
         if fillTypeIndex and fillTypeIndex > 0 then
@@ -416,126 +539,276 @@ function CombineCalibrationGUI:draw()
             local l10nKey = "fillType_" .. string.lower(rawName)
             if g_i18n:hasText(l10nKey) then
                 displayName = g_i18n:getText(l10nKey)
+            else
+                local cleanName = rawName:gsub("_", " ")
+                displayName = cleanName:sub(1,1):upper() .. cleanName:sub(2):lower()
             end
         end
         return displayName
     end
-    
-    setTextAlignment(RenderText.ALIGN_CENTER)
-    renderText(cropX + 0.025 + 0.07, cy + 0.005, ui.fontSize, getLocalizedCropName(memory.currentCrop))
-    
-    self:drawButton(cropX + 0.025 + 0.14, cy, 0.025, 0.035, ">", function()
-        self:cycleCrop(1)
-    end)
-    
-    cy = cy - ui.lineHeight * 1.2
-    
-    -- EN: Mode buttons: AUTO applies optimal settings (server-side randomized); LOAD PRESET loads the user's saved profile.
-    -- UA: Кнопки режиму: AUTO застосовує оптимальні налаштування (з серверною рандомізацією); LOAD PRESET завантажує збережений профіль.
-    local btnWidth = (w - ui.margin * 2.5 - 0.01) / 2
-    
-    self:drawButton(x + ui.margin, cy, btnWidth, 0.035, g_i18n:getText("rhm_gui_btn_auto"), function()
-        memory:requestAutoSettings()
-    end, {0.9, 0.7, 0.1, 1})
-    
-    self:drawButton(x + w - ui.margin - btnWidth, cy, btnWidth, 0.035, g_i18n:getText("rhm_gui_btn_load_preset"), function()
-        memory:loadUserPreset()
-    end, {0.1, 0.5, 0.9, 1})
-    
-    cy = cy - ui.lineHeight * 1.5
-    
-    -- EN: Parameter rows — dynamically built from machine type active param list.
-    -- UA: Рядки параметрів — динамічно будуються зі списку активних параметрів типу машини.
-    local machineType = spec.machineType or "grain"
-    local activeParams = CombineSettingsDatabase:getParamsForMachineType(machineType)
-    
-    for _, param in ipairs(activeParams) do
-        local labelKey = CombineSettingsDatabase:getParamLabel(machineType, param)
-        local label = g_i18n:hasText(labelKey) and g_i18n:getText(labelKey) or param
-        self:drawParameterRow(x + ui.margin, cy, w - ui.margin*2, param, label, memory, ui, machineType)
-        cy = cy - ui.lineHeight
-    end
-    
-    cy = cy - ui.lineHeight * 0.5
-    
-    -- EN: Settings efficiency/loss preview: reads checkSettingsForCrop from CombineMemory.
-    --     effPenalty < 0 means a speed bonus; lossPenalty <= 0 means no crop loss.
-    -- UA: Попередній перегляд ефективності/втрат: читає checkSettingsForCrop з CombineMemory.
-    --     effPenalty < 0 означає бонус швидкості; lossPenalty <= 0 означає відсутність втрат.
-    local load = (spec.loadCalculator and spec.loadCalculator.engineLoad or 0) * 100
-    
-    local effPenalty = 0
-    local lossPenalty = 0
-    if memory.currentCrop then
-        effPenalty, lossPenalty, _ = memory:checkSettingsForCrop(memory.currentCrop)
-    end
-    
-    -- EN: Format speed and loss text. Negative effPenalty = speed bonus (+X%).
-    -- UA: Форматуємо текст швидкості та втрат. Від'ємний effPenalty = бонус швидкості (+X%).
-    local speedStr = ""
-    local lossStr = ""
-    
-    if effPenalty < 0 then
-        local speedBonus = math.abs(effPenalty) * 5.0
-        speedStr = string.format("Speed: +%.1f%%", speedBonus)
-    else
-        speedStr = string.format("Speed: -%.1f%%", effPenalty)
-    end
-    
-    -- EN: Loss values below 0 are mathematical bonuses in core logic, displayed as 0.0% to the player.
-    -- UA: Значення втрат нижче 0 є математичними бонусами в ядрі логіки, відображаються гравцеві як 0.0%.
-    if lossPenalty <= 0 then
-        lossStr = "Loss: 0.0%"
-    else
-        lossStr = string.format("Loss: +%.1f%%", lossPenalty)
-    end
-    
-    local textStr = speedStr .. "  |  " .. lossStr
-    
-    -- EN: Color the penalty line: red if any penalty > 0.5%, green if speed bonus and no loss.
-    -- UA: Кольоруємо рядок штрафу: червоний якщо будь-який штраф > 0.5%, зелений якщо бонус швидкості і немає втрат.
-    local textColor = ui.colors.text
-    if lossPenalty > 0.5 or effPenalty > 0.5 then
-        textColor = ui.colors.error or {0.9, 0.2, 0.2, 1.0}
-    elseif effPenalty < -0.1 and lossPenalty <= 0.5 then
-        textColor = ui.colors.success or {0.2, 0.8, 0.2, 1.0}
-    end
-    
+
+    -- EN: Crop selector: [<] CROPNAME [>] — left side of the row.
+    -- UA: Вибір культури: [<] НАЗВА [>] — ліва частина рядка.
+    local cropLabel = g_i18n:getText("rhm_gui_crop")
+    setTextBold(true)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(unpack(ui.colors.textDim))
-    renderText(x + ui.margin, cy + 0.005, ui.fontSize, string.format(g_i18n:getText("rhm_gui_engine_load"), load))
-    
-    setTextAlignment(RenderText.ALIGN_RIGHT)
-    setTextColor(unpack(textColor))
-    renderText(x + w - ui.margin, cy + 0.005, ui.fontSize, textStr)
+    renderText(x + ui.margin, cy + 0.010, ui.fontSize * 0.9, cropLabel)
 
-    cy = cy - ui.lineHeight * 1.5
-    
-    -- EN: Profile management buttons: save current settings, or reset to defaults.
-    -- UA: Кнопки управління профілем: зберегти поточні налаштування або скинути до типових.
-    self:drawButton(x + ui.margin, cy, 0.12, 0.035, g_i18n:getText("rhm_gui_btn_save"), function()
-        memory:saveCurrentProfile(memory.currentCrop)
+    local cropNavX = x + ui.margin + 0.030
+    local arrowW = 0.020
+    self:drawButton(cropNavX, cy + 0.004, arrowW, ui.buttonH, "<", function()
+        self:cycleCrop(-1)
     end)
-    
-    self:drawButton(x + w - ui.margin - 0.12, cy, 0.12, 0.035, g_i18n:getText("rhm_gui_btn_reset"), function()
-        memory:requestResetSettings()
-    end, ui.colors.warning)
-    
-    cy = cy - ui.lineHeight
-    
-    -- EN: Close hint text at the bottom (e.g. "Press K to close").
-    -- UA: Підказка закриття внизу (напр. "Натисніть K для закриття").
+
+    local cropName = getLocalizedCropName(memory.currentCrop)
+    setTextBold(true)
     setTextAlignment(RenderText.ALIGN_CENTER)
+    setTextColor(unpack(memory.currentCrop and ui.colors.text or ui.colors.textDim))
+    renderText(cropNavX + arrowW + 0.052, cy + 0.010, ui.fontSize, cropName)
+
+    self:drawButton(cropNavX + arrowW + 0.104, cy + 0.004, arrowW, ui.buttonH, ">", function()
+        self:cycleCrop(1)
+    end)
+
+    -- EN: AUTO button — visible only with Auto Pilot upgrade (tier 4).
+    --     Shows a dimmed "LOCKED" label for lower tiers.
+    -- UA: Кнопка AUTO — тільки з апгрейдом Автопілот (рівень 4).
+    local autoBtnW = 0.065
+    local autoBtnX = x + w - ui.margin - autoBtnW
+    if upgradeLevel >= 4 then
+        self:drawButton(autoBtnX, cy + 0.003, autoBtnW, ui.buttonH + 0.003, g_i18n:getText("rhm_gui_btn_auto"), function()
+            memory:requestAutoSettings()
+        end, ui.colors.buttonAuto)
+    else
+        -- EN: Dimmed locked state — no click handler.
+        self:drawButton(autoBtnX, cy + 0.003, autoBtnW, ui.buttonH + 0.003, "LOCKED", nil, {0.15, 0.15, 0.13, 0.40})
+    end
+
+    -- EN: Thin separator under crop row.
+    -- UA: Тонкий розділювач під рядком культури.
+    self:drawRect(x + ui.margin, cy - 0.004, w - ui.margin * 2, 0.001, ui.colors.separator)
+
+    cy = cy - ui.margin * 0.3
+
+    -- ── Parameter sections ──────────────────────────────────────────────────
+    local activeParams = CombineSettingsDatabase:getParamsForMachineType(machineType)
+    local drawnParams = {}
+
+    for _, section in ipairs(SECTIONS_ORDERED) do
+        -- EN: Check if any param in this section is active for the current machine type.
+        -- UA: Перевіряємо чи є активний параметр цієї секції для поточного типу машини.
+        local hasAny = false
+        for _, p in ipairs(activeParams) do
+            if PARAM_SECTION_MAP[p] == section.key then
+                hasAny = true
+                break
+            end
+        end
+        
+        if hasAny then
+            -- EN: Center section header background bar.
+            -- UA: Центрована фонова плашка для заголовку секції.
+            cy = cy - ui.sectionGap
+            self:drawRect(x, cy + 0.002, w, ui.sectionGap - 0.004, {0, 0, 0, 0.40}) -- Darker strip
+
+            setTextBold(true)
+            setTextAlignment(RenderText.ALIGN_CENTER)
+            setTextColor(unpack(ui.colors.accent))
+            local sectionName = g_i18n:hasText(section.label) and g_i18n:getText(section.label) or section.key
+            renderText(x + w * 0.5, cy + 0.006, ui.sectionSize, string.upper(sectionName))
+
+            -- EN: No horizontal rule anymore if centered, it looks cleaner.
+            -- UA: Більше немає горизонтальної лінії, якщо текст по центру, так виглядає чистіше.
+
+            -- EN: Draw each parameter in this section (in original DB order).
+            -- UA: Малюємо кожен параметр цієї секції (у порядку оригінальної БД).
+            for _, p in ipairs(activeParams) do
+                if PARAM_SECTION_MAP[p] == section.key and not drawnParams[p] then
+                    cy = cy - ui.lineHeight
+                    local labelKey = CombineSettingsDatabase:getParamLabel(machineType, p)
+                    local label = g_i18n:hasText(labelKey) and g_i18n:getText(labelKey) or p
+                    self:drawParameterRow(x + ui.margin, cy, w - ui.margin * 2, p, label, memory, ui, machineType)
+                    drawnParams[p] = true
+                end
+            end
+        end
+    end
+
+    -- EN: PERFORMANCE section — remaining unlisted params + targetEngineLoad.
+    -- UA: Секція PERFORMANCE — решта незгрупованих параметрів + targetEngineLoad.
+    -- PERFORMANCE section background.
+    cy = cy - ui.sectionGap
+    self:drawRect(x, cy + 0.002, w, ui.sectionGap - 0.004, {0, 0, 0, 0.40}) -- Darker strip
+
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_CENTER)
+    setTextColor(unpack(ui.colors.accent))
+    local perfLabel = g_i18n:hasText("rhm_ui_section_performance") and g_i18n:getText("rhm_ui_section_performance") or "PERFORMANCE"
+    renderText(x + w * 0.5, cy + 0.006, ui.sectionSize, string.upper(perfLabel))
+
+    -- EN: Draw any active params not yet grouped (catch-all).
+    -- UA: Малюємо незгруповані активні параметри (catch-all).
+    for _, p in ipairs(activeParams) do
+        if not drawnParams[p] then
+            cy = cy - ui.lineHeight
+            local labelKey = CombineSettingsDatabase:getParamLabel(machineType, p)
+            local label = g_i18n:hasText(labelKey) and g_i18n:getText(labelKey) or p
+            self:drawParameterRow(x + ui.margin, cy, w - ui.margin * 2, p, label, memory, ui, machineType)
+            drawnParams[p] = true
+        end
+    end
+
+    -- EN: Target Engine Load always last in PERFORMANCE.
+    -- UA: Target Engine Load завжди останній у PERFORMANCE.
+    cy = cy - ui.lineHeight
+    local loadLabel = g_i18n:hasText("rhm_target_load") and g_i18n:getText("rhm_target_load") or "Target Engine Load"
+    self:drawParameterRow(x + ui.margin, cy, w - ui.margin * 2, "targetEngineLoad", loadLabel, memory, ui, machineType)
+
+    cy = cy - ui.margin * 0.8
+    self:drawRect(x + ui.margin, cy, w - ui.margin * 2, 0.001, ui.colors.separator)
+    cy = cy - ui.margin * 0.6
+
+    -- ── Upgrade System ──────────────────────────────────────────────────────
+    cy = cy - ui.sectionGap
+    self:drawRect(x, cy + 0.002, w, ui.sectionGap - 0.004, {0, 0, 0, 0.40})
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_CENTER)
+    setTextColor(unpack(ui.colors.accent))
+    renderText(x + w * 0.5, cy + 0.006, ui.sectionSize, "UPGRADES")
+
+    -- EN: Show current tier and next purchasable upgrade.
+    cy = cy - ui.lineHeight * 0.8
+    local curName  = CombineMemory.UPGRADE_NAMES[upgradeLevel] or "?"
+    setTextBold(false)
+    setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(unpack(ui.colors.textDim))
-    renderText(x + w/2, cy + 0.005, ui.fontSize * 0.9, g_i18n:getText("rhm_gui_close_hint"))
-    
-    -- EN: Process scroll wheel adjustments (debounced). Only fires when mouse is inside GUI.
-    --     Shift held = 5x step multiplier for faster adjustment.
-    -- UA: Обробляємо прокрутку колесом (з захистом від дребезгу). Спрацьовує лише коли миша в середині GUI.
-    --     Shift = 5x множник кроку для швидшого регулювання.
+    renderText(x + ui.margin, cy + 0.006, ui.statusSize,
+        string.format("Installed: Tier %d — %s", upgradeLevel, curName))
+
+    -- EN: If max tier, show "Fully Upgraded"; otherwise show Buy button for next tier.
+    local nextTier = upgradeLevel + 1
+    if nextTier <= 4 then
+        local nextCost = CombineMemory.UPGRADE_COSTS[nextTier] or 0
+        local nextName = CombineMemory.UPGRADE_NAMES[nextTier] or "?"
+        local nextDesc = CombineMemory.UPGRADE_DESC[nextTier] or ""
+        local btnLabel = string.format("BUY: %s ($%d)", nextName, nextCost)
+        cy = cy - ui.lineHeight * 0.85
+        self:drawButton(x + ui.margin, cy, w - ui.margin * 2, 0.026, btnLabel, function()
+            local ok, reason = memory:purchaseUpgrade(nextTier)
+            if ok then
+                print(string.format("RHM: [Upgrade] Tier %d purchased successfully", nextTier))
+            else
+                print(string.format("RHM: [Upgrade] Purchase failed: %s", reason or "?"))
+            end
+        end, {0.05, 0.12, 0.20, 0.95})
+        setTextBold(false)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(0.70, 0.68, 0.65, 0.80)
+        renderText(x + w * 0.5, cy - ui.statusSize - 0.001, ui.statusSize * 0.9, nextDesc)
+    else
+        cy = cy - ui.lineHeight * 0.5
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(0.24, 0.72, 0.47, 1.00)
+        renderText(x + w * 0.5, cy + 0.006, ui.statusSize, "Fully Upgraded")
+    end
+
+    cy = cy - ui.margin * 0.8
+    self:drawRect(x + ui.margin, cy, w - ui.margin * 2, 0.001, ui.colors.separator)
+    cy = cy - ui.margin * 0.6
+
+    -- ── Harvest Report (Calibration tier 1+) ────────────────────────────────
+    -- EN: Show session stats + grade + reset button when player has at least Calibration upgrade.
+    -- UA: Показуємо статистику сесії + оцінку + кнопку скидання при наявності рівня 1+.
+    if upgradeLevel >= 1 and spec.loadCalculator then
+        cy = cy - ui.sectionGap
+        self:drawRect(x, cy + 0.002, w, ui.sectionGap - 0.004, {0, 0, 0, 0.40})
+        setTextBold(true)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(unpack(ui.colors.accent))
+        renderText(x + w * 0.5, cy + 0.006, ui.sectionSize, "HARVEST REPORT")
+
+        local unitSystem = (g_realisticHarvestManager and g_realisticHarvestManager.settings
+                           and g_realisticHarvestManager.settings.unitSystem) or 1
+        local s = spec.loadCalculator:getSessionSummary(unitSystem)
+
+        setTextBold(false)
+        setTextAlignment(RenderText.ALIGN_LEFT)
+
+        -- EN: Two-column layout for stats.
+        local col1x = x + ui.margin
+        local col2x = x + w * 0.50
+
+        local function statRow(label, val1, label2, val2)
+            cy = cy - ui.lineHeight * 0.75
+            setTextColor(unpack(ui.colors.textDim))
+            renderText(col1x,  cy + 0.006, ui.statusSize, label)
+            setTextColor(unpack(ui.colors.text))
+            renderText(col1x + 0.040, cy + 0.006, ui.statusSize, val1)
+            if label2 then
+                setTextColor(unpack(ui.colors.textDim))
+                renderText(col2x,         cy + 0.006, ui.statusSize, label2)
+                setTextColor(unpack(ui.colors.text))
+                renderText(col2x + 0.040, cy + 0.006, ui.statusSize, val2 or "—")
+            end
+        end
+
+        statRow("Time:", s.time,     "Area:", s.area)
+        statRow("Load:", s.avgLoad,  "Peak:", s.peakLoad)
+        statRow("Loss:", s.avgLoss,  "Hdr:", s.avgHdrLoss)
+        statRow("Plugs:", s.plugs,   "Yield:", s.mass)
+
+        -- EN: Efficiency grade — color-coded.
+        cy = cy - ui.lineHeight * 0.80
+        local gradeChar = s.grade:sub(1,1)
+        local gr, gg, gb = 0.24, 0.72, 0.47
+        if gradeChar == "B" then gr, gg, gb = 0.55, 0.80, 0.30
+        elseif gradeChar == "C" then gr, gg, gb = 0.91, 0.78, 0.25
+        elseif gradeChar == "D" or gradeChar == "F" then gr, gg, gb = 0.89, 0.29, 0.29
+        end
+        setTextBold(true)
+        setTextAlignment(RenderText.ALIGN_CENTER)
+        setTextColor(gr, gg, gb, 1.0)
+        renderText(x + w * 0.5, cy + 0.004, ui.fontSize * 1.1,
+            string.format("Efficiency: %s  (%d/100)", s.grade, s.score))
+        setTextBold(false)
+
+        -- EN: Reset Session button.
+        cy = cy - ui.lineHeight * 0.85
+        self:drawButton(x + ui.margin, cy, w - ui.margin * 2, 0.024, "RESET SESSION", function()
+            if spec.loadCalculator then
+                spec.loadCalculator:resetSession()
+            end
+        end, {0.15, 0.08, 0.05, 0.90})
+
+        cy = cy - ui.margin * 0.6
+        self:drawRect(x + ui.margin, cy, w - ui.margin * 2, 0.001, ui.colors.separator)
+        cy = cy - ui.margin * 0.4
+    end
+
+    -- ── Action buttons ──────────────────────────────────────────────────────
+    -- Row 1: Load Preset | Save Profile
+    cy = cy - ui.lineHeight * 1.0
+    local btnWidth = (w - ui.margin * 2.5 - 0.008) / 2
+
+    self:drawButton(x + ui.margin, cy, btnWidth, 0.026, g_i18n:getText("rhm_gui_btn_load_preset"), function()
+        memory:loadUserPreset()
+    end, ui.colors.button)
+
+    self:drawButton(x + w - ui.margin - btnWidth, cy, btnWidth, 0.026, g_i18n:getText("rhm_gui_btn_save"), function()
+        memory:saveCurrentProfile(memory.currentCrop)
+    end, ui.colors.buttonSave)
+
+    -- Row 2: Reset Default
+    cy = cy - ui.lineHeight * 1.0
+    local resetBtnW = w - ui.margin * 2
+    self:drawButton(x + ui.margin, cy, resetBtnW, 0.026, g_i18n:getText("rhm_gui_btn_reset"), function()
+        memory:requestResetSettings()
+    end, ui.colors.buttonReset)
+
+    -- ── Scroll wheel handling ───────────────────────────────────────────────
     if self.lastScrollTimeStamp + self.scrollDelayMs < g_time then
         local mx, my = g_inputBinding:getMousePosition()
-        
         if mx >= ui.x and mx <= ui.x + ui.w and my >= ui.y and my <= ui.y + ui.h then
             if Input.isMouseButtonPressed(Input.MOUSE_BUTTON_WHEEL_UP) then
                 self.lastScrollTimeStamp = g_time
@@ -546,47 +819,47 @@ function CombineCalibrationGUI:draw()
             end
         end
     end
-    
-    -- EN: Reset text rendering state.
-    -- UA: Скидаємо стан відображення тексту.
-    setTextBold(false)
-    setTextColor(1, 1, 1, 1)
-    setTextAlignment(RenderText.ALIGN_LEFT)
+
+    self:_resetTextState()
 end
 
--- EN: Draws a single parameter row: label on left, formatted value in center,
---     [-] and [+] buttons on right. Color-codes value green when within tolerance of optimal.
---     Highlights the value box in cyan when hovered, and sets hoveredParameter for wheel scroll.
---     Uses UnitConverter.formatSetting to display physical units (RPM, mm) instead of %.
---     Smart step logic: calculates physical steps (10 RPM / 0.5 mm) then converts back to %.
--- UA: Малює один рядок параметра: мітка ліворуч, відформатоване значення по центру,
---     кнопки [-] та [+] праворуч. Кодує значення зеленим коли в межах допуску від оптимуму.
---     Підсвічує область значення блакитним при наведенні, встановлює hoveredParameter для прокрутки.
---     Використовує UnitConverter.formatSetting для відображення фізичних одиниць (об/хв, мм) замість %.
---     Розумна логіка кроку: розраховує фізичні кроки (10 об/хв / 0.5 мм) і конвертує назад у %.
+-- EN: Draws a single parameter row with: label | physical value | status hint | progress bar | [-] [+] buttons.
+--     Progress bar shows current value position relative to full range (0-100%),
+--     with a white marker at the optimal position from the database.
+--     Status hint shows "optimal" / "^ low" / "v high" with color coding.
+--     Smart step logic calculates physical increments (10 RPM / 0.5 mm) and converts back to %.
+-- UA: Малює один рядок параметра: мітка | фізичне значення | підказка статусу | прогрес-бар | кнопки [-] [+].
+--     Прогрес-бар показує позицію поточного значення відносно повного діапазону (0-100%),
+--     з білим маркером в оптимальній позиції з бази даних.
+--     Підказка статусу показує "optimal" / "^ low" / "v high" з кольоровим кодуванням.
+--     Розумна логіка кроку розраховує фізичні кроки (10 об/хв / 0.5 мм) і конвертує назад у %.
 function CombineCalibrationGUI:drawParameterRow(x, y, w, param, label, memory, ui, machineType)
     local val = memory.currentSettings[param] or 0
     local optimal = 0
+    local tolerance = 5
     local isOptimal = false
-    
-    local isHovered = self:checkHover(x, y - 0.003, w, ui.lineHeight)
-    
-    -- EN: Check if current value is within tolerance of optimal from DB.
-    -- UA: Перевіряємо чи поточне значення знаходиться в межах допуску від оптимуму з БД.
+    local hasOptimal = false
+
+    -- EN: Row hover highlight.
+    -- UA: Підсвічування рядка при наведенні.
+    local isRowHovered = self:checkHover(x, y - 0.005, w, ui.lineHeight)
+    if isRowHovered then
+        self:drawRect(x, y - 0.005, w, ui.lineHeight, ui.colors.paramRowHover)
+    end
+
+    -- EN: Fetch optimal value and tolerance from database.
+    -- UA: Отримуємо оптимальне значення та допуск з бази даних.
     if CombineSettingsDatabase and memory.currentCrop then
         local settings = CombineSettingsDatabase:getSettingsForCrop(memory.currentCrop)
         if settings and settings[param] then
             optimal = settings[param].optimal
-            local tolerance = settings[param].tolerance or 5
-            -- EN: Value is highlighted as optimal when within tolerance range.
-            -- UA: Значення підсвічується як оптимальне коли в межах діапазону допуску.
-            if math.abs(val - optimal) <= tolerance then
-                isOptimal = true
-            end
+            tolerance = settings[param].tolerance or 5
+            isOptimal = math.abs(val - optimal) <= tolerance
+            hasOptimal = true
         end
     end
-    
-    -- EN: Format value using physical units (RPM, mm) via UnitConverter.
+
+    -- EN: Format value with physical units (RPM, mm) via UnitConverter.
     -- UA: Форматуємо значення у фізичних одиницях (об/хв, мм) через UnitConverter.
     local displayStr = ""
     if UnitConverter and UnitConverter.formatSetting then
@@ -594,59 +867,135 @@ function CombineCalibrationGUI:drawParameterRow(x, y, w, param, label, memory, u
     else
         displayStr = string.format("%d%%", val)
     end
-    
-    setTextAlignment(RenderText.ALIGN_LEFT)
-    setTextColor(unpack(ui.colors.text))
-    renderText(x, y + 0.005, ui.fontSize, label)
-    
-    -- EN: Value box occupies 25-75% of row width for hover detection.
-    -- UA: Область значення займає 25-75% ширини рядка для виявлення наведення.
-    local valBoxX = x + w * 0.25
-    local valBoxW = w * 0.5
-    local valBoxY = y - 0.003
-    local valBoxH = ui.lineHeight
-    
-    local isValueHovered = self:checkHover(valBoxX, valBoxY, valBoxW, valBoxH)
-    if isValueHovered then
+
+    -- EN: Layout proportions within the row.
+    --   [0 .. labelW] label
+    --   [labelW .. valEndX] value (centered)
+    --   [valEndX .. btnStartX] status hint
+    --   [btnStartX .. end] [-] [+] buttons
+    -- UA: Пропорції розмітки в рядку.
+    local labelW    = w * 0.38
+    local valW      = w * 0.24
+    local valX      = x + labelW
+    local valEndX   = valX + valW
+    local btnAreaW  = ui.buttonW * 2 + 0.006
+    local btnStartX = x + w - btnAreaW
+    local statusW   = btnStartX - valEndX - 0.004
+
+    -- EN: Determine value color and status text based on optimality.
+    -- UA: Визначаємо колір значення та текст статусу на основі оптимальності.
+    local valColor, statusText, statusColor
+
+    if memory.autoSwitchEnabled then
+        valColor    = ui.colors.textDim
+        statusText  = "auto"
+        statusColor = ui.colors.textDim
+    elseif not hasOptimal then
+        valColor    = ui.colors.text
+        statusText  = ""
+        statusColor = ui.colors.textDim
+    elseif isOptimal then
+        valColor    = ui.colors.success
+        statusText  = "optimal"
+        statusColor = {ui.colors.success[1], ui.colors.success[2], ui.colors.success[3], 0.60}
+    else
+        local deviation = math.abs(val - optimal) - tolerance
+        if deviation > 20 then
+            valColor    = ui.colors.error
+            statusColor = ui.colors.error
+        else
+            valColor    = ui.colors.warning
+            statusColor = ui.colors.warning
+        end
+        statusText = (val < optimal) and "^ low" or "v high"
+    end
+
+    -- EN: Teal highlight when mouse is over the value area (scroll wheel target).
+    -- UA: Бірюзове підсвічування коли миша над областю значення (ціль колеса прокрутки).
+    local valBoxHovered = self:checkHover(valX, y - 0.005, valW, ui.lineHeight)
+    if valBoxHovered then
+        self.hoveredParameter = param
+        valColor = ui.colors.teal
+    end
+
+    -- EN: Also track hover for the full value+status area.
+    -- UA: Також відстежуємо наведення для всієї області значення+статусу.
+    if isRowHovered then
         self.hoveredParameter = param
     end
-    
-    local valColor = isOptimal and ui.colors.success or ui.colors.text
-    if memory.autoSwitchEnabled then valColor = ui.colors.textDim end -- EN: Dim when AUTO mode active / UA: Приглушений при активному AUTO режимі
-    
-    -- EN: Cyan highlight when mouse is over the value box.
-    -- UA: Блакитне підсвічування коли миша над областю значення.
-    if isValueHovered then
-        valColor = {0.6, 1.0, 1.0, 1}
-    end
-    
+
+    -- ── Label ──────────────────────────────────────────────────────────────
+    setTextBold(true)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    setTextColor(unpack(ui.colors.textDim))
+    renderText(x, y + 0.014, ui.fontSize, label)
+
+    -- ── Value ──────────────────────────────────────────────────────────────
     setTextAlignment(RenderText.ALIGN_CENTER)
     setTextColor(unpack(valColor))
-    renderText(x + w * 0.5, y + 0.005, ui.fontSize, displayStr)
-    
-    -- EN: Smart step logic for [-]/[+] buttons.
-    --     Calculates physical increment (10 RPM or 0.5 mm), snaps to grid first,
-    --     then converts back to %. Falls back to 1% steps if UnitConverter unavailable.
-    -- UA: Розумна логіка кроку для кнопок [-]/[+].
-    --     Розраховує фізичний крок (10 об/хв або 0.5 мм), спочатку прив'язується до сітки,
-    --     потім конвертує назад у %. Відступає до кроків 1% якщо UnitConverter недоступний.
+    renderText(valX + valW / 2, y + 0.014, ui.fontSize, displayStr)
+
+    -- ── Status hint ────────────────────────────────────────────────────────
+    if statusText ~= "" and statusW > 0.008 then
+        setTextBold(false)
+        setTextAlignment(RenderText.ALIGN_LEFT)
+        setTextColor(unpack(statusColor))
+        renderText(valEndX + 0.002, y + 0.014, ui.statusSize, statusText)
+    end
+
+    -- ── Progress bar ───────────────────────────────────────────────────────
+    -- EN: Bar spans from value column start to button area. Shows current % position.
+    --     White marker pin at the optimal % position.
+    -- UA: Бар від початку колонки значень до кнопок. Показує позицію поточного % значення.
+    --     Білий маркер на позиції оптимального % значення.
+    if hasOptimal then
+        local barX = valX
+        local barW = btnStartX - valX - 0.004
+        local barY = y + 0.005
+        local barH = 0.003
+
+        -- EN: Bar track.
+        -- UA: Трек бару.
+        self:drawRect(barX, barY, barW, barH, ui.colors.barBg)
+
+        -- EN: Bar fill (current value).
+        -- UA: Заповнення бару (поточне значення).
+        local fillPct = math.max(0, math.min(val / 100.0, 1.0))
+        local fillColor = isOptimal and ui.colors.success
+                        or (val < optimal - tolerance and ui.colors.warning or ui.colors.warning)
+        if math.abs(val - optimal) - tolerance > 20 then
+            fillColor = ui.colors.error
+        end
+        self:drawRect(barX, barY, fillPct * barW, barH, fillColor)
+
+        -- The optimal pin marker has been removed based on user feedback.
+    end
+
+    -- ── Smart step logic ───────────────────────────────────────────────────
+    -- EN: Calculates physical increment (10 RPM or 0.5 mm), snaps to grid,
+    --     converts back to %. Falls back to 1% steps if UnitConverter unavailable.
+    -- UA: Розраховує фізичний крок (10 об/хв або 0.5 мм), прив'язується до сітки,
+    --     конвертує назад у %. Відступає до кроків 1% якщо UnitConverter недоступний.
     local function performSmartStep(direction)
+        if param == "targetEngineLoad" then
+            memory:updateSetting(param, val + (direction * 5))
+            return
+        end
+
         if UnitConverter and UnitConverter.percentToPhysical then
             local physVal = UnitConverter.percentToPhysical(param, val, machineType)
             local range = UnitConverter.getPhysicalRange(param, machineType)
-            
+
             if range then
                 local stepValue = 1
                 if range.unit == "RPM" then
                     stepValue = 10
                 elseif range.unit == "mm" then
-                    stepValue = 0.5 -- EN: 0.5mm for fine sieve adjustment / UA: 0.5мм для точного регулювання решет
+                    stepValue = 0.5
                 end
-                
+
                 local targetPhysVal = physVal
-                
-                -- EN: Snap to nearest grid point first to eliminate floating-point drift.
-                -- UA: Спочатку прив'язуємось до найближчої точки сітки для усунення дрейфу з плаваючою точкою.
+
                 if stepValue >= 1 then
                     local snapped = math.floor((physVal / stepValue) + 0.5) * stepValue
                     if math.abs(physVal - snapped) > 0.01 then
@@ -659,28 +1008,24 @@ function CombineCalibrationGUI:drawParameterRow(x, y, w, param, label, memory, u
                         targetPhysVal = snapped + (stepValue * direction)
                     end
                 else
-                    -- EN: Fractional step (0.5mm): same snap logic but for sub-1 increments.
-                    -- UA: Дробовий крок (0.5мм): та ж логіка прив'язки але для часток одиниці.
                     local snapped = math.floor((physVal / stepValue) + 0.5) * stepValue
                     if math.abs(physVal - snapped) > 0.01 then
-                         if direction > 0 then
+                        if direction > 0 then
                             targetPhysVal = math.ceil(physVal / stepValue) * stepValue
-                         else
+                        else
                             targetPhysVal = math.floor(physVal / stepValue) * stepValue
-                         end
+                        end
                     else
-                         targetPhysVal = snapped + (stepValue * direction)
+                        targetPhysVal = snapped + (stepValue * direction)
                     end
                 end
-                
+
                 local targetPercent = UnitConverter.physicalToPercent(param, targetPhysVal, machineType)
-                
-                -- EN: If the physical change doesn't move even 1%, force a 1% change to prevent being stuck.
-                -- UA: Якщо фізична зміна не рухає навіть 1%, примусово змінюємо на 1% щоб уникнути застрягання.
+
                 if math.abs(targetPercent - val) < 0.5 then
                     targetPercent = val + (direction * 1)
                 end
-                
+
                 memory:updateSetting(param, math.floor(targetPercent + 0.5))
             else
                 memory:updateSetting(param, val + direction)
@@ -690,40 +1035,76 @@ function CombineCalibrationGUI:drawParameterRow(x, y, w, param, label, memory, u
         end
     end
 
-    -- EN: [-] and [+] buttons positioned at the right edge of the row.
-    -- UA: Кнопки [-] та [+] розміщені біля правого краю рядка.
-    self:drawButton(x + w - ui.buttonW*2 - 0.005, y, ui.buttonW, ui.buttonH, "-", function()
+    -- ── [-] and [+] buttons ────────────────────────────────────────────────
+    self:drawButton(btnStartX, y + 0.004, ui.buttonW, ui.buttonH, "-", function()
         performSmartStep(-1)
     end)
-    
-    self:drawButton(x + w - ui.buttonW, y, ui.buttonW, ui.buttonH, "+", function()
+
+    self:drawButton(btnStartX + ui.buttonW + 0.004, y + 0.004, ui.buttonW, ui.buttonH, "+", function()
         performSmartStep(1)
     end)
 end
 
--- EN: Draws a colored button rectangle and its label. Text turns cyan on hover.
---     Registers the button in self.buttons for click hit-testing in mouseEvent.
--- UA: Малює кольоровий прямокутник кнопки та її мітку. Текст стає блакитним при наведенні.
---     Реєструє кнопку в self.buttons для перевірки кліків у mouseEvent.
+-- EN: Draws a colored button. Text and hover color differ for [-] and [+] buttons
+--     to give instant visual feedback on the direction of change.
+-- UA: Малює кольорову кнопку. Колір тексту та наведення відрізняються для кнопок [-] та [+],
+--     щоб дати миттєвий візуальний зворотній зв'язок про напрямок зміни.
 function CombineCalibrationGUI:drawButton(x, y, w, h, text, callback, colorOverride)
     local isHovered = self:checkHover(x, y, w, h)
-    
-    local bgColor = colorOverride or self.ui.colors.button
-    self:drawRect(x, y, w, h, bgColor)
-    
-    setTextAlignment(RenderText.ALIGN_CENTER)
-    if isHovered then
-        setTextColor(0.6, 1.0, 1.0, 1)  -- EN: Bright cyan on hover / UA: Яскраво-блакитний при наведенні
+
+    local bgColor
+    if colorOverride then
+        bgColor = isHovered and {
+            colorOverride[1] * 1.4,
+            colorOverride[2] * 1.4,
+            colorOverride[3] * 1.4,
+            colorOverride[4]
+        } or colorOverride
+    elseif isHovered then
+        if text == "+" then
+            bgColor = self.ui.colors.buttonHover  -- green tint applied via text color
+        elseif text == "-" then
+            bgColor = self.ui.colors.buttonHover  -- red tint applied via text color
+        else
+            bgColor = self.ui.colors.buttonHover
+        end
     else
-        setTextColor(1, 1, 1, 1)
+        bgColor = self.ui.colors.button
     end
-    renderText(x + w/2, y + h/2 - self.ui.fontSize/2.5, self.ui.fontSize, text)
-    
+
+    self:drawRect(x, y, w, h, bgColor)
+
+    setTextAlignment(RenderText.ALIGN_CENTER)
+    setTextBold(true)
+
+    if isHovered then
+        if text == "+" then
+            setTextColor(0.40, 1.00, 0.55, 1.0)   -- EN: Bright green / UA: Яскраво-зелений
+        elseif text == "-" then
+            setTextColor(1.00, 0.40, 0.40, 1.0)   -- EN: Bright red / UA: Яскраво-червоний
+        else
+            setTextColor(unpack(self.ui.colors.accent))  -- EN: Amber for action buttons / UA: Бурштин для кнопок дій
+        end
+    else
+        if text == "+" then
+            setTextColor(0.38, 0.36, 0.32, 1.0)
+        elseif text == "-" then
+            setTextColor(0.38, 0.36, 0.32, 1.0)
+        elseif colorOverride then
+            setTextColor(unpack(self.ui.colors.text))
+        else
+            setTextColor(unpack(self.ui.colors.textDim))
+        end
+    end
+
+    renderText(x + w / 2, y + h / 2 - self.ui.fontSize / 2.5, self.ui.fontSize, text)
+    setTextBold(false)
+
     table.insert(self.buttons, {x=x, y=y, w=w, h=h, callback=callback})
 end
 
--- EN: Draws a solid-color rectangle using the persistent overlay object. Cheaper than creating new overlays.
--- UA: Малює суцільний кольоровий прямокутник використовуючи постійний об'єкт оверлею. Дешевше за створення нових оверлеїв.
+-- EN: Draws a solid-color rectangle using the persistent overlay object.
+-- UA: Малює суцільний кольоровий прямокутник використовуючи постійний об'єкт оверлею.
 function CombineCalibrationGUI:drawRect(x, y, w, h, color)
     if not self.overlay then return end
     local r, g, b, a = unpack(color)
@@ -733,10 +1114,16 @@ function CombineCalibrationGUI:drawRect(x, y, w, h, color)
     self.overlay:render()
 end
 
--- EN: Returns true if the current mouse position (from last mouseEvent or getMousePosition fallback)
---     is inside the given rectangle. Used for hover detection on all interactive elements.
--- UA: Повертає true якщо поточна позиція миші (із останнього mouseEvent або запасного getMousePosition)
---     знаходиться всередині заданого прямокутника. Використовується для виявлення наведення на всі інтерактивні елементи.
+-- EN: Resets text rendering state to engine defaults.
+-- UA: Скидає стан рендерингу тексту до значень рушія.
+function CombineCalibrationGUI:_resetTextState()
+    setTextBold(false)
+    setTextColor(1, 1, 1, 1)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+end
+
+-- EN: Returns true if the current mouse position is inside the given rectangle.
+-- UA: Повертає true якщо поточна позиція миші знаходиться всередині заданого прямокутника.
 function CombineCalibrationGUI:checkHover(x, y, w, h)
     local mx, my = self.mouseX, self.mouseY
     if not mx or not my then
@@ -745,60 +1132,49 @@ function CombineCalibrationGUI:checkHover(x, y, w, h)
     return mx >= x and mx <= x + w and my >= y and my <= y + h
 end
 
--- EN: Full mouse event handler. Tracks mouse position, consumes all wheel events inside the GUI,
---     dispatches scroll wheel to smart parameter adjustment (with Shift=5x multiplier),
---     and dispatches left-clicks to the registered button callbacks.
---     Returns true to consume the event and prevent it from reaching FS25 camera/other systems.
--- UA: Повний обробник подій миші. Відстежує позицію миші, поглинає всі події колеса в середині GUI,
---     направляє прокрутку до розумного регулювання параметрів (Shift=5x множник),
---     та направляє ліві кліки до зареєстрованих колбеків кнопок.
---     Повертає true щоб поглинути подію і запобігти її потраплянню до камери/інших систем FS25.
+-- EN: Full mouse event handler. Tracks position, consumes wheel events inside GUI,
+--     dispatches scroll to smart parameter adjustment (Shift=5x), dispatches clicks to buttons.
+-- UA: Повний обробник подій миші. Відстежує позицію, поглинає події колеса всередині GUI,
+--     направляє прокрутку до розумного регулювання (Shift=5x), направляє кліки до кнопок.
 function CombineCalibrationGUI:mouseEvent(posX, posY, isDown, isUp, button)
     if not self.isOpen then return end
-    
-    -- EN: Track mouse position every frame for hover effects.
-    -- UA: Відстежуємо позицію миші кожен кадр для ефектів наведення.
+
     self.mouseX = posX
     self.mouseY = posY
-    
+
     local insideGUI = posX >= self.ui.x and posX <= self.ui.x + self.ui.w and
                       posY >= self.ui.y and posY <= self.ui.y + self.ui.h
-    
-    -- EN: Scroll wheel inside GUI: adjust the hovered parameter with smart physical steps.
-    --     Shift held applies a 5x multiplier for fast adjustment.
-    -- UA: Прокрутка колесом всередині GUI: регулює наведений параметр з розумними фізичними кроками.
-    --     Shift застосовує 5x множник для швидкого регулювання.
+
     local isWheel = button == Input.MOUSE_BUTTON_WHEEL_UP or button == Input.MOUSE_BUTTON_WHEEL_DOWN
     if isWheel and insideGUI then
         if isDown then
             local wheelUp = button == Input.MOUSE_BUTTON_WHEEL_UP
             local delta = wheelUp and 1 or -1
-            
-            -- EN: Shift modifier: 5x faster adjustment.
-            -- UA: Модифікатор Shift: регулювання у 5 разів швидше.
+
             if Input.isKeyPressed(Input.KEY_lshift) or Input.isKeyPressed(Input.KEY_rshift) then
                 delta = delta * 5
             end
-            
+
             local param = self:getParameterAtMouse(posX, posY)
             if param then
                 local spec = self.activeVehicle.spec_rhm_Combine
                 if spec and spec.combineMemory then
                     local currentVal = spec.combineMemory.currentSettings[param]
                     local machineType = spec.machineType or "grain"
-                    
-                    -- EN: Smart step: use physical unit increments (10 RPM, 0.5 mm) same as button logic.
-                    -- UA: Розумний крок: використовуємо фізичні кроки (10 об/хв, 0.5 мм) як у логіці кнопок.
+
+                    if param == "targetEngineLoad" then
+                        spec.combineMemory:updateSetting(param, currentVal + (delta * 5))
+                        return true
+                    end
+
                     if UnitConverter and UnitConverter.percentToPhysical then
                         local physVal = UnitConverter.percentToPhysical(param, currentVal, machineType)
                         local range = UnitConverter.getPhysicalRange(param, machineType)
-                        
+
                         if range then
                             local stepValue = range.unit == "RPM" and 10 or 0.5
                             local targetPhysVal = physVal
-                            
-                            -- EN: Grid snapping for scroll wheel same as buttons.
-                            -- UA: Прив'язка до сітки для колеса прокрутки так само як у кнопок.
+
                             local snapped = math.floor((physVal / stepValue) + 0.5) * stepValue
                             if math.abs(physVal - snapped) > 0.01 then
                                 if delta > 0 then targetPhysVal = math.ceil(physVal / stepValue) * stepValue
@@ -812,14 +1188,12 @@ function CombineCalibrationGUI:mouseEvent(posX, posY, isDown, isUp, button)
                             end
 
                             local targetPercent = UnitConverter.physicalToPercent(param, targetPhysVal, machineType)
-                            
-                            -- EN: Force a 1% move if stuck at precision boundary.
-                            -- UA: Примусово рухаємо на 1% якщо застрягли на межі точності.
+
                             if math.abs(targetPercent - currentVal) < 0.5 then
                                 targetPercent = currentVal + (delta > 0 and 1 or -1)
                                 if math.abs(delta) > 1 then targetPercent = targetPercent + delta end
                             end
-                            
+
                             spec.combineMemory:updateSetting(param, math.floor(targetPercent + 0.5))
                         else
                             spec.combineMemory:updateSetting(param, currentVal + delta)
@@ -830,11 +1204,9 @@ function CombineCalibrationGUI:mouseEvent(posX, posY, isDown, isUp, button)
                 end
             end
         end
-        return true  -- EN: Always consume wheel events inside GUI / UA: Завжди поглинаємо події колеса всередині GUI
+        return true
     end
-    
-    -- EN: Dispatch left-click to button callbacks.
-    -- UA: Направляємо лівий клік до колбеків кнопок.
+
     if isDown and button == Input.MOUSE_BUTTON_LEFT then
         for _, btn in ipairs(self.buttons) do
             if posX >= btn.x and posX <= btn.x + btn.w and posY >= btn.y and posY <= btn.y + btn.h then
@@ -845,26 +1217,22 @@ function CombineCalibrationGUI:mouseEvent(posX, posY, isDown, isUp, button)
             end
         end
     end
-    
-    -- EN: Consume all events inside GUI to prevent click-through.
-    -- UA: Поглинаємо всі події всередині GUI щоб запобігти прокиданню кліків.
+
     if insideGUI then
-       return true
+        return true
     end
 end
 
 -- EN: Wheel scroll handler used by the debounced polling in draw().
 --     Applies adjustment to hoveredParameter if one is set. Shift=5x multiplier.
--- UA: Обробник прокрутки колесом використовуваний дебаунсним опитуванням у draw().
+-- UA: Обробник прокрутки колесом для дебаунсного опитування у draw().
 --     Застосовує регулювання до hoveredParameter якщо він встановлений. Shift=5x множник.
 function CombineCalibrationGUI:handleWheelScroll(direction, posX, posY)
     local delta = direction
-    -- EN: Shift modifier for 5x faster adjustment.
-    -- UA: Модифікатор Shift для 5x швидшого регулювання.
     if Input.isKeyPressed(Input.KEY_lshift) or Input.isKeyPressed(Input.KEY_rshift) then
         delta = delta * 5
     end
-    
+
     if self.activeVehicle and self.activeVehicle.spec_rhm_Combine then
         local spec = self.activeVehicle.spec_rhm_Combine
         if spec.combineMemory and self.hoveredParameter then
@@ -874,13 +1242,13 @@ function CombineCalibrationGUI:handleWheelScroll(direction, posX, posY)
     end
 end
 
--- EN: Returns the name of the parameter the mouse is currently hovering over.
---     hoveredParameter is set each frame during drawParameterRow() calls.
+-- EN: Returns the name of the parameter currently hovered by the mouse.
 -- UA: Повертає назву параметра над яким зараз знаходиться миша.
---     hoveredParameter встановлюється кожен кадр під час викликів drawParameterRow().
 function CombineCalibrationGUI:getParameterAtMouse(x, y)
     if self.hoveredParameter then
         return self.hoveredParameter
     end
     return nil
 end
+
+print("[OK] CombineCalibrationGUI loaded")

--- a/src/hud/DraggableHUD.lua
+++ b/src/hud/DraggableHUD.lua
@@ -9,16 +9,9 @@
 DraggableHUD = {}
 DraggableHUD.__index = DraggableHUD
 
--- EN: Minimum drag time delay before a click becomes a drag (milliseconds).
--- UA: Мінімальна затримка часу перед тим як клік стане перетягуванням (мілісекунди).
 DraggableHUD.DRAG_DELAY_MS = 15
-
--- EN: Minimum pixel distance moved before treating as a drag (prevents accidental moves on click).
--- UA: Мінімальна відстань переміщення в пікселях щоб вважати це перетягуванням (запобігає випадковому переміщенню при кліку).
 DraggableHUD.DRAG_LIMIT = 2
 
--- EN: Creates a new HUD instance. Resources are loaded separately via :load().
--- UA: Створює новий екземпляр HUD. Ресурси завантажуються окремо через :load().
 function DraggableHUD.new(modDirectory, settings)
     local self = setmetatable({}, DraggableHUD)
 
@@ -26,27 +19,25 @@ function DraggableHUD.new(modDirectory, settings)
     self.settings = settings
     self.vehicle = nil
 
-    -- EN: Live data cache updated each frame from the combine spec.
-    -- UA: Кеш живих даних що оновлюється щокадру зі специфікації комбайна.
     self.data = {
         load = 0,
         yield = 0,
         speed = 0,
         cropLoss = 0,
+        headerLoss = 0,
         tonPerHour = 0,
         litersPerHour = 0,
-        recommendedSpeed = 0
+        recommendedSpeed = 0,
+        isPlugged = false,
+        plugTimerPct = 0,
+        moistureLabel = "",
     }
 
-    -- EN: Normalized screen-space dimensions (0-1). Scaled in load() based on UI scale.
-    -- UA: Нормалізовані розміри в просторі екрану (0-1). Масштабуються в load() за масштабом UI.
     self.width = 0.11
     self.height = 0.18
     self.headerHeight = 0.028
     self.uiScale = 1.0
 
-    -- EN: Drag state — tracking whether the user is currently dragging the HUD.
-    -- UA: Стан перетягування — відстежуємо чи зараз користувач перетягує HUD.
     self.dragging = false
     self.dragStartX = nil
     self.dragOffsetX = nil
@@ -56,39 +47,38 @@ function DraggableHUD.new(modDirectory, settings)
 
     self.backgroundOverlay = nil
     self.headerOverlay = nil
+    self.accentLineOverlay = nil
     self.icons = {}
 
     return self
 end
 
--- EN: Loads HUD textures, icons, and calculates initial position based on UI scale.
---     Must be called after the mission is loaded (textures require the game to be initialized).
--- UA: Завантажує текстури HUD, іконки та розраховує початкову позицію за масштабом UI.
---     Має викликатись після завантаження місії (текстури потребують ініціалізацію гри).
 function DraggableHUD:load()
     self.uiScale = 1.0
     if g_gameSettings then
         self.uiScale = g_gameSettings:getValue("uiScale") or 1.0
     end
 
-    -- EN: Scale all dimensions to match the game's UI scale setting.
-    -- UA: Масштабуємо всі розміри відповідно до налаштування масштабу UI гри.
     self.width = 0.09 * self.uiScale
     self.height = 0.155 * self.uiScale
     self.headerHeight = 0.030 * self.uiScale
 
     self.x, self.y = self:getPosition()
 
-    -- EN: Create the colored header strip (green) above the main panel.
-    -- UA: Створюємо кольорову смугу заголовку (зелену) над основною панеллю.
-    local headerTexture = self.modDirectory .. "textures/hud_background.dds"
-    self.headerOverlay = Overlay.new(headerTexture, self.x, self.y + self.height, self.width, self.headerHeight)
-    self.headerOverlay:setColor(0.22323, 0.40724, 0.00368, 1)
+    local bgTexture = self.modDirectory .. "textures/hud_background.dds"
 
-    -- EN: Create the semi-transparent dark background panel.
-    -- UA: Створюємо напівпрозору темну фонову панель.
-    self.backgroundOverlay = Overlay.new(headerTexture, self.x, self.y, self.width, self.height)
-    self.backgroundOverlay:setColor(0, 0, 0, 0.5)
+    -- EN: Dark amber-tinted header strip replacing the old green one.
+    -- UA: Темна бурштинова смуга заголовку замість старої зеленої.
+    self.headerOverlay = Overlay.new(bgTexture, self.x, self.y + self.height, self.width, self.headerHeight)
+    self.headerOverlay:setColor(0.09, 0.07, 0.03, 1.0)
+
+    -- Removed the thin amber accent line at the top of the header as requested.
+    self.accentLineOverlay = nil
+
+    -- EN: Dark olive background panel, more opaque for better readability.
+    -- UA: Темно-оливкова фонова панель, більш непрозора для кращої читабельності.
+    self.backgroundOverlay = Overlay.new(bgTexture, self.x, self.y, self.width, self.height)
+    self.backgroundOverlay:setColor(0.04, 0.05, 0.03, 0.92)
 
     self:loadIcons(self.uiScale)
 
@@ -97,10 +87,6 @@ function DraggableHUD:load()
     end
 end
 
--- EN: Loads icon overlay objects for each HUD row (load, yield, speed, loss, productivity).
---     Icons are sized proportionally to the UI scale and aspect ratio.
--- UA: Завантажує оверлеї іконок для кожного рядка HUD (навантаження, врожайність, швидкість, втрати, продуктивність).
---     Іконки масштабуються пропорційно до масштабу UI та співвідношення сторін.
 function DraggableHUD:loadIcons(uiScale)
     local iconHeight = 0.024 * self.uiScale
     local iconWidth = iconHeight / g_screenAspectRatio
@@ -118,12 +104,10 @@ function DraggableHUD:loadIcons(uiScale)
     for name, filename in pairs(iconNames) do
         local iconPath = iconsPath .. filename .. ".dds"
         local icon = Overlay.new(iconPath, 0, 0, iconWidth, iconHeight)
-        icon:setColor(1, 1, 1, 0.95)
+        icon:setColor(1, 1, 1, 0.80)
         self.icons[name] = icon
     end
 
-    -- EN: Default all row visibility settings to true if not yet set in saved settings.
-    -- UA: Встановлюємо видимість всіх рядків за замовчуванням на true якщо ще не задано.
     if self.settings.showLoad == nil then self.settings.showLoad = true end
     if self.settings.showYield == nil then self.settings.showYield = true end
     if self.settings.showSpeed == nil then self.settings.showSpeed = true end
@@ -131,17 +115,11 @@ function DraggableHUD:loadIcons(uiScale)
     if self.settings.showProductivity == nil then self.settings.showProductivity = true end
 end
 
--- EN: Returns the HUD position — from saved settings if available and on-screen, or auto-positioned
---     left of the speed meter, with a fallback to (0.7, 0.05).
--- UA: Повертає позицію HUD — із збережених налаштувань якщо є і в межах екрану, або авто-позиціонується
---     зліва від спідометра, з запасним варіантом (0.7, 0.05).
 function DraggableHUD:getPosition()
     local x = self.settings.hudPosX
     local y = self.settings.hudPosY
 
     if x and y then
-        -- EN: Allow small margin for floating point drift, reset if well off-screen.
-        -- UA: Допускаємо невелику похибку, скидаємо якщо далеко за межами екрану.
         if x >= -0.1 and x <= 1.1 and y >= -0.1 and y <= 1.1 then
             x = math.max(0, math.min(1 - (self.width or 0), x))
             y = math.max(0, math.min(1 - (self.height or 0), y))
@@ -153,8 +131,6 @@ function DraggableHUD:getPosition()
         end
     end
 
-    -- EN: Auto-position: left of the game's speed meter. Guard against uninitialized speedBg.
-    -- UA: Авто-позиціонування: зліва від спідометра гри. Захист від неініціалізованого speedBg.
     if g_currentMission and g_currentMission.hud and g_currentMission.hud.speedMeter then
         local speedMeter = g_currentMission.hud.speedMeter
         if speedMeter.speedBg and speedMeter.speedBg.x and speedMeter.speedBg.x > 0.01 then
@@ -164,25 +140,19 @@ function DraggableHUD:getPosition()
         end
     end
 
-    return 0.7, 0.05 -- EN: Last-resort fallback position / UA: Останній запасний варіант позиції
+    return 0.7, 0.05
 end
 
--- EN: Sets the HUD top-left position (normalized screen coords).
--- UA: Встановлює верхню ліву позицію HUD (нормалізовані координати екрану).
 function DraggableHUD:setPosition(x, y)
     self.x = x
     self.y = y
 end
 
--- EN: Sets the active combine vehicle. Clears live data when nil is passed.
--- UA: Встановлює активний комбайн. Очищає живі дані коли передано nil.
 function DraggableHUD:setVehicle(vehicle)
     self.vehicle = vehicle
     if vehicle then
         self:update(vehicle)
     else
-        -- EN: Reset all displayed metrics when no vehicle is active.
-        -- UA: Скидаємо всі відображувані метрики коли немає активного транспортного засобу.
         self.data.load = 0
         self.data.yield = 0
         self.data.speed = 0
@@ -193,10 +163,6 @@ function DraggableHUD:setVehicle(vehicle)
     end
 end
 
--- EN: Updates live data from the vehicle's rhm_Combine spec and handles drag movement.
---     Called every frame. Drag movement is processed here for smooth real-time updating.
--- UA: Оновлює живі дані зі специфікації rhm_Combine транспортного засобу та обробляє перетягування.
---     Викликається щоразу за кадр. Рух перетягування обробляється тут для плавного оновлення.
 function DraggableHUD:update(dt)
     local vehicle = self.vehicle
     if not vehicle then return end
@@ -204,18 +170,18 @@ function DraggableHUD:update(dt)
     local spec = vehicle.spec_rhm_Combine
     if not spec or not spec.data then return end
 
-    -- EN: Pull latest values from the combine's live data table.
-    -- UA: Беремо останні значення з таблиці живих даних комбайна.
     self.data.load             = spec.data.load or 0
     self.data.yield            = spec.data.yield or 0
     self.data.cropLoss         = spec.data.cropLoss or 0
+    self.data.headerLoss       = spec.data.headerLoss or 0
     self.data.tonPerHour       = spec.data.tonPerHour or 0
     self.data.litersPerHour    = spec.data.litersPerHour or 0
     self.data.recommendedSpeed = spec.data.recommendedSpeed or 0
     self.data.speed            = vehicle:getLastSpeed() or 0
+    self.data.isPlugged        = spec.data.isPlugged or false
+    self.data.plugTimerPct     = spec.data.plugTimerPct or 0
+    self.data.moistureLabel    = spec.data.moistureLabel or ""
 
-    -- EN: Move HUD to follow mouse during drag (processed every frame for smoothness).
-    -- UA: Переміщуємо HUD слідуючи за мишею під час перетягування (обробляється щокадру для плавності).
     if self.dragging then
         if g_inputBinding and g_inputBinding.getMousePosition then
             local posX, posY = g_inputBinding:getMousePosition()
@@ -226,10 +192,6 @@ function DraggableHUD:update(dt)
     end
 end
 
--- EN: Renders the complete HUD including header, settings button, and metric rows.
---     Skipped when on server, when HUD is hidden, or when no vehicle is active.
--- UA: Відображає повний HUD включаючи заголовок, кнопку налаштувань та рядки метрик.
---     Пропускається на сервері, коли HUD прихований, або коли немає активного транспортного засобу.
 function DraggableHUD:draw()
     if not g_currentMission:getIsClient() then return end
     if not self.settings.showHUD then return end
@@ -237,65 +199,68 @@ function DraggableHUD:draw()
 
     self:updateSize()
 
-    -- EN: Sync overlay positions and dimensions to match current layout.
-    -- UA: Синхронізуємо позиції та розміри оверлеїв з поточним розмічуванням.
     self.backgroundOverlay:setPosition(self.x, self.y)
     self.headerOverlay:setPosition(self.x, self.y + self.height)
     self.backgroundOverlay:setDimension(self.width, self.height)
+    self.headerOverlay:setDimension(self.width, self.headerHeight)
 
     self.backgroundOverlay:render()
     self.headerOverlay:render()
 
-    -- EN: Draw "Realistic Harvesting" title text centered in the header.
-    -- UA: Малюємо назву "Realistic Harvesting" по центру заголовку.
+
+
+    -- EN: Amber title text in header.
+    -- UA: Бурштиновий заголовок.
     setTextBold(true)
     setTextAlignment(RenderText.ALIGN_CENTER)
-    setTextColor(1, 1, 1, 1)
-    local titleTextSize = 0.013
+    setTextColor(0.83, 0.54, 0.04, 1.0)
+    local titleTextSize = 0.012 * self.uiScale
     local headerTextX = self.x + self.width / 2
     local titleTextY = self.y + self.height + self.headerHeight * 0.65
     renderText(headerTextX, titleTextY, titleTextSize, "Realistic Harvesting")
 
-    -- EN: Draw "Settings" sub-label below the title with hover color change.
-    -- UA: Малюємо підпис "Settings" під назвою зі зміною кольору при наведенні.
     setTextBold(false)
     setTextAlignment(RenderText.ALIGN_CENTER)
 
-    local settingsButtonArea = {
-        x = self.x,
-        y = self.y + self.height,
-        w = self.width,
-        h = self.headerHeight * 0.4
-    }
+    local settingsTextSize = 0.009 * self.uiScale
+    local btnW = 0.040 * self.uiScale
+    local btnH = self.headerHeight * 0.40
+    local btnX = self.x + (self.width - btnW) / 2
+    local btnY = self.y + self.height + self.headerHeight * 0.06
+
+    local settingsButtonArea = { x = btnX, y = btnY, w = btnW, h = btnH }
     local mx, my = g_inputBinding:getMousePosition()
     local isHovered = mx >= settingsButtonArea.x and mx <= settingsButtonArea.x + settingsButtonArea.w and
                       my >= settingsButtonArea.y and my <= settingsButtonArea.y + settingsButtonArea.h
 
-    if isHovered then
-        setTextColor(0.6, 1.0, 1.0, 1)  -- EN: Cyan on hover / UA: Блакитний при наведенні
-    else
-        setTextColor(0.8, 0.8, 1.0, 1)  -- EN: Light blue default / UA: Блакитний за замовчуванням
+    if self.backgroundOverlay then
+        local btnBgTex = self.modDirectory .. "textures/hud_background.dds"
+        local rect = Overlay.new(btnBgTex, btnX, btnY, btnW, btnH)
+        if isHovered then
+            rect:setColor(0.83, 0.54, 0.04, 0.22)
+        else
+            rect:setColor(0.00, 0.00, 0.00, 0.28)
+        end
+        rect:render()
+        rect:delete()
     end
 
-    local settingsTextSize = 0.009
-    local settingsTextY = self.y + self.height + self.headerHeight * 0.20
-    renderText(headerTextX, settingsTextY, settingsTextSize, "Settings")
+    if isHovered then
+        setTextColor(0.83, 0.54, 0.04, 1.0)
+    else
+        setTextColor(0.38, 0.36, 0.32, 1.0)
+    end
+
+    local textYOffset = btnY + (btnH - settingsTextSize) / 2 + 0.002
+    renderText(headerTextX, textYOffset, settingsTextSize, "Settings")
     setTextBold(false)
 
-    -- EN: Store button area for mouse event hit-testing.
-    -- UA: Зберігаємо область кнопки для перевірки попадань мишею.
     self.menuButtonArea = settingsButtonArea
 
     self:drawContent()
     setTextBold(false)
 end
 
--- EN: Draws the metric data rows (load, yield, productivity, crop loss, speed).
---     Each row consists of an icon and a formatted text value with color coding.
---     Uses UnitConverter for metric/imperial/bushel formatting.
--- UA: Малює рядки метрик (навантаження, врожайність, продуктивність, втрати, швидкість).
---     Кожен рядок містить іконку та відформатоване текстове значення з кодуванням кольором.
---     Використовує UnitConverter для форматування метрик/американських/бушелів.
 function DraggableHUD:drawContent()
     local textSize   = 0.015 * self.uiScale
     local lineHeight = 0.028 * self.uiScale
@@ -309,7 +274,7 @@ function DraggableHUD:drawContent()
 
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextBold(true)
-    setTextColor(1, 1, 1, 0.95)
+    setTextColor(0.91, 0.87, 0.78, 0.95)
 
     local unitSystem = self.settings.unitSystem or 1
     local fruitType = nil
@@ -317,8 +282,8 @@ function DraggableHUD:drawContent()
         fruitType = self.vehicle.spec_combine.lastValidInputFruitType
     end
 
-    -- EN: Row 1 — Engine Load (%).
-    -- UA: Рядок 1 — Навантаження двигуна (%).
+    -- EN: Row 1 — Engine Load.
+    -- UA: Рядок 1 — Навантаження двигуна.
     if self.settings.showLoad then
         local loadColor = self:getLoadColor(self.data.load)
         self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "load",
@@ -326,8 +291,8 @@ function DraggableHUD:drawContent()
         textY = textY - lineHeight
     end
 
-    -- EN: Row 2 — Yield (t/ha, bu/ac, etc.).
-    -- UA: Рядок 2 — Врожайність (т/га, бу/акр тощо).
+    -- EN: Row 2 — Yield.
+    -- UA: Рядок 2 — Врожайність.
     if self.settings.showYield then
         local yieldVal = self.data.yield or 0
         local yieldStr
@@ -341,8 +306,8 @@ function DraggableHUD:drawContent()
         textY = textY - lineHeight
     end
 
-    -- EN: Row 3 — Productivity (t/h or bu/h).
-    -- UA: Рядок 3 — Продуктивність (т/год або бу/год).
+    -- EN: Row 3 — Productivity.
+    -- UA: Рядок 3 — Продуктивність.
     if self.settings.showProductivity then
         local prodVal = self.data.tonPerHour or 0
         local prodStr
@@ -356,9 +321,35 @@ function DraggableHUD:drawContent()
         textY = textY - lineHeight
     end
 
-    -- EN: Row 4 — Crop Loss (%). Color-coded: green=optimal, yellow=mild loss, red=high loss.
-    -- UA: Рядок 4 — Втрати зерна (%). Кольорове кодування: зелений=оптимум, жовтий=помірні, червоний=великі.
-    if self.settings.showCropLoss then
+    -- EN: Rows 4+ — gated on Calibration System upgrade (tier 1+).
+    -- UA: Рядки 4+ — потребують апгрейду Система Калібрування (рівень 1+).
+    local rhmSpec = self.vehicle and self.vehicle.spec_rhm_Combine
+    local upgradeLevel = rhmSpec and rhmSpec.combineMemory and (rhmSpec.combineMemory.upgradeLevel or 0) or 0
+    local hasCalibration = upgradeLevel >= 1
+
+    -- EN: PLUG WARNING — highest priority, shown in urgent red when rotor is plugged.
+    --     Displayed regardless of upgrade level (critical safety information).
+    -- UA: ПОПЕРЕДЖЕННЯ ЗАСМІЧЕННЯ — найвищий пріоритет, показується червоним при засміченні ротора.
+    if self.data.isPlugged then
+        local blinkOn = math.floor((g_time or 0) / 400) % 2 == 0
+        local r, g, b = 0.95, 0.20, 0.20
+        if blinkOn then r, g, b = 1.0, 0.5, 0.1 end
+        self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "load",
+            "!! PLUGGED !!", 100, r, g, b)
+        textY = textY - lineHeight
+    elseif (self.data.plugTimerPct or 0) >= 50 then
+        -- EN: Pre-plug warning when load has been 130%+ for over 5 seconds.
+        -- UA: Попереднє попередження при навантаженні 130%+ більше 5 секунд.
+        local pct = self.data.plugTimerPct
+        local r = 0.91 + (pct - 50) / 50 * 0.08
+        self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "load",
+            string.format("PLUG RISK %.0f%%", pct), 100, r, 0.35, 0.20)
+        textY = textY - lineHeight
+    end
+
+    -- EN: Threshing Crop Loss row (Calibration tier 1+).
+    -- UA: Рядок втрат при обмолоті (рівень 1+).
+    if self.settings.showCropLoss and hasCalibration then
         local lossVal = self.data.cropLoss or 0
         local lossStr
         if lossVal > 0.1 then
@@ -369,18 +360,43 @@ function DraggableHUD:drawContent()
             lossStr = "0%"
         end
 
-        local r, g, b = 1, 1, 1
-        if lossVal > 3.0 then           r, g, b = 0.9, 0.1, 0.1  -- EN: Red (high loss) / UA: Червоний (великі втрати)
-        elseif lossVal > 1.0 then       r, g, b = 0.9, 0.8, 0.1  -- EN: Yellow (moderate) / UA: Жовтий (помірні)
-        elseif lossVal < -0.1 then      r, g, b = 0.2, 1.0, 0.2  -- EN: Bright green (bonus) / UA: Яскраво-зелений (бонус)
-        else                            r, g, b = 0.2, 0.8, 0.2  end  -- EN: Green (optimal) / UA: Зелений (оптимум)
+        local r, g, b = 0.91, 0.87, 0.78
+        if lossVal > 3.0 then       r, g, b = 0.89, 0.29, 0.29
+        elseif lossVal > 1.0 then   r, g, b = 0.91, 0.78, 0.25
+        elseif lossVal < -0.1 then  r, g, b = 0.24, 0.90, 0.55
+        else                        r, g, b = 0.24, 0.72, 0.47
+        end
 
-        self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "loss", lossStr, lossVal, r, g, b)
+        self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "loss",
+            "Thr " .. lossStr, lossVal, r, g, b)
         textY = textY - lineHeight
     end
 
-    -- EN: Row 5 — Speed (current / recommended). Red/yellow when over recommended limit.
-    -- UA: Рядок 5 — Швидкість (поточна / рекомендована). Червоний/жовтий при перевищенні ліміту.
+    -- EN: Header Loss row — visible when Calibration installed and loss is meaningful (>0.1%).
+    --     Color: green under 1%, amber 1-3%, red above 3% (get your foot off the gas!).
+    -- UA: Рядок втрат на жатці — показується при рівні 1+ і втратах >0.1%.
+    if hasCalibration and (self.data.headerLoss or 0) > 0.1 then
+        local hdrLoss = self.data.headerLoss
+        local hdrStr  = string.format("Hdr -%.1f%%", hdrLoss)
+        local r, g, b = 0.24, 0.72, 0.47
+        if hdrLoss > 3.0 then     r, g, b = 0.89, 0.29, 0.29
+        elseif hdrLoss > 1.0 then r, g, b = 0.91, 0.78, 0.25
+        end
+        self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "loss",
+            hdrStr, hdrLoss, r, g, b)
+        textY = textY - lineHeight
+    end
+
+    -- EN: Moisture indicator — subtle dim row when conditions are non-optimal (tier 1+).
+    -- UA: Індикатор вологості — тихий рядок при несприятливих умовах (рівень 1+).
+    if hasCalibration and (self.data.moistureLabel or "") ~= "" then
+        self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "yield",
+            self.data.moistureLabel, 0, 0.65, 0.60, 0.40)
+        textY = textY - lineHeight
+    end
+
+    -- EN: Speed row (current / recommended).
+    -- UA: Рядок 5 — Швидкість (поточна / рекомендована).
     if self.settings.showSpeed then
         local currentSpeed = self.data.speed
         local recSpeed = self.data.recommendedSpeed or 0
@@ -402,30 +418,37 @@ function DraggableHUD:drawContent()
             end
         end
 
-        local r, g, b = 1, 1, 1
+        local r, g, b = 0.91, 0.87, 0.78
         if recSpeed > 0 then
-            if currentSpeed > (recSpeed + 2) then r, g, b = 1, 0.4, 0.4    -- EN: Over speed / UA: Перевищення
-            elseif currentSpeed > recSpeed then   r, g, b = 1, 1, 0.4  end -- EN: Near limit / UA: Близько до ліміту
+            if currentSpeed > (recSpeed + 2) then   r, g, b = 0.89, 0.29, 0.29
+            elseif currentSpeed > recSpeed then     r, g, b = 0.91, 0.78, 0.25
+            end
         end
 
         self:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, "speed", speedStr, 0, r, g, b)
     end
 end
 
--- EN: Recalculates HUD height based on how many rows are enabled.
---     Adjusts the Y position so the header line stays fixed while the body shrinks/grows.
--- UA: Перераховує висоту HUD залежно від кількості увімкнених рядків.
---     Регулює позицію Y щоб лінія заголовку залишалась фіксованою поки тіло зменшується/збільшується.
 function DraggableHUD:updateSize()
+    local rhmSpec = self.vehicle and self.vehicle.spec_rhm_Combine
+    local upgradeLevel = rhmSpec and rhmSpec.combineMemory and (rhmSpec.combineMemory.upgradeLevel or 0) or 0
+    local hasCalibration = upgradeLevel >= 1
+
     local rowCount = 0
-    if self.settings.showLoad then rowCount = rowCount + 1 end
-    if self.settings.showYield then rowCount = rowCount + 1 end
+    if self.settings.showLoad        then rowCount = rowCount + 1 end
+    if self.settings.showYield        then rowCount = rowCount + 1 end
     if self.settings.showProductivity then rowCount = rowCount + 1 end
-    if self.settings.showCropLoss then rowCount = rowCount + 1 end
+    if self.settings.showCropLoss and hasCalibration then rowCount = rowCount + 1 end
+    -- EN: Header loss row — shown when Calibration (tier 1+) installed and loss > 0.1%.
+    if hasCalibration and (self.data.headerLoss or 0) > 0.1 then rowCount = rowCount + 1 end
+    -- EN: Moisture indicator — one extra row when conditions are non-optimal (tier 1+).
+    if hasCalibration and (self.data.moistureLabel or "") ~= "" then rowCount = rowCount + 1 end
+    -- EN: Plug warning — always visible when plugged (critical safety info).
+    if self.data.isPlugged then rowCount = rowCount + 1 end
     if self.settings.showSpeed then rowCount = rowCount + 1 end
 
     local lineHeight  = 0.028 * self.uiScale
-    local padding     = 0.01 * self.uiScale
+    local padding     = 0.010 * self.uiScale
     local targetHeight = math.max(0.01 * self.uiScale, (rowCount * lineHeight) + padding)
 
     if math.abs(self.height - targetHeight) > 0.0001 then
@@ -436,58 +459,53 @@ function DraggableHUD:updateSize()
     end
 end
 
--- EN: Draws a single HUD row: an icon on the left and a formatted text value.
---     Optional RGB color overrides the default white text color.
--- UA: Малює один рядок HUD: іконка зліва та відформатоване текстове значення.
---     Необов'язковий RGB колір замінює стандартний білий колір тексту.
 function DraggableHUD:drawRow(iconX, textX, textY, iconWidth, iconHeight, textSize, iconName, text, value, r, g, b)
     local icon = self.icons[iconName]
     if icon then
         local iconY = textY + textSize / 2 - iconHeight / 2
         icon:setPosition(iconX, iconY)
-        icon:setColor(1, 1, 1, 0.95)
+        icon:setColor(0.91, 0.87, 0.78, 0.60)
         icon:render()
     end
 
     if r and g and b then
         setTextColor(r, g, b, 0.95)
     else
-        setTextColor(1, 1, 1, 0.95)
+        setTextColor(0.91, 0.87, 0.78, 0.95)
     end
     renderText(textX, textY, textSize, text)
-end
 
--- EN: Maps engine load value to a display color: white (low), yellow (moderate), red (high).
--- UA: Відображає значення навантаження двигуна на колір: білий (низьке), жовтий (помірне), червоний (високе).
-function DraggableHUD:getLoadColor(load)
-    if load < 50 then
-        return {1, 1, 1}    -- EN: White / UA: Білий
-    elseif load < 80 then
-        return {1, 1, 0.4}  -- EN: Yellow / UA: Жовтий
-    else
-        return {1, 0.4, 0.4} -- EN: Red / UA: Червоний
+    if self.backgroundOverlay then
+        local lineY = textY - 0.004
+        local lineTex = self.modDirectory .. "textures/hud_background.dds"
+        local line = Overlay.new(lineTex, self.x + 0.005, lineY, self.width - 0.010, 0.0007)
+        line:setColor(1, 1, 1, 0.07)
+        line:render()
+        line:delete()
     end
 end
 
--- EN: Returns true if the given position is within the draggable header area.
--- UA: Повертає true якщо задана позиція знаходиться в межах перетягуваної області заголовку.
+-- EN: Engine load → color: warm white < 60%, amber-yellow 60-85%, red > 85%.
+-- UA: Навантаження двигуна → колір: тепло-білий < 60%, бурштиново-жовтий 60-85%, червоний > 85%.
+function DraggableHUD:getLoadColor(load)
+    if load < 60 then
+        return {0.91, 0.87, 0.78}
+    elseif load < 85 then
+        return {0.91, 0.78, 0.25}
+    else
+        return {0.89, 0.29, 0.29}
+    end
+end
+
 function DraggableHUD:isMouseOverHeader(posX, posY)
     return posX >= self.x and posX <= (self.x + self.width) and
            posY >= (self.y + self.height) and posY <= (self.y + self.height + self.headerHeight)
 end
 
--- EN: Handles mouse button events. Routes Settings button clicks and manages drag start/stop.
---     The Settings button click opens the calibration GUI via the manager.
---     Drag saves position on mouse-up for persistence.
--- UA: Обробляє події кнопок миші. Маршрутизує кліки кнопки Settings та керує початком/кінцем перетягування.
---     Клік кнопки Settings відкриває GUI калібрування через менеджер.
---     Перетягування зберігає позицію при відпусканні миші для збереження.
 function DraggableHUD:mouseEvent(posX, posY, isDown, isUp, button)
     if not self.settings.showHUD then return false end
     if button ~= Input.MOUSE_BUTTON_LEFT then return false end
 
-    -- EN: Check click on "Settings" button in header to open the calibration GUI.
-    -- UA: Перевіряємо клік на кнопку "Settings" у заголовку для відкриття GUI калібрування.
     if self.menuButtonArea and isDown then
         if posX >= self.menuButtonArea.x and posX <= (self.menuButtonArea.x + self.menuButtonArea.w) and
            posY >= self.menuButtonArea.y and posY <= (self.menuButtonArea.y + self.menuButtonArea.h) then
@@ -498,8 +516,6 @@ function DraggableHUD:mouseEvent(posX, posY, isDown, isUp, button)
         end
     end
 
-    -- EN: Start drag on mouse-down over the header area.
-    -- UA: Починаємо перетягування при натисканні миші над областю заголовку.
     if isDown and self:isMouseOverHeader(posX, posY) then
         if not self.dragging then
             self.dragStartX  = posX
@@ -512,8 +528,6 @@ function DraggableHUD:mouseEvent(posX, posY, isDown, isUp, button)
             return true
         end
     elseif isUp then
-        -- EN: Stop drag on mouse-up and save the position once to avoid per-frame saves.
-        -- UA: Зупиняємо перетягування при відпусканні миші і зберігаємо позицію один раз щоб уникнути збереження щокадру.
         if self.dragging then
             self.dragging = false
             if RHM_Debug and RHM_Debug.isEnabled("UI") then
@@ -529,22 +543,14 @@ function DraggableHUD:mouseEvent(posX, posY, isDown, isUp, button)
     return false
 end
 
--- EN: Moves the HUD to the given position, clamped to keep it fully visible on-screen.
---     Saves the position to settings in memory only (save to disk happens on drag stop).
--- UA: Переміщує HUD до заданої позиції, обмежуючи щоб він залишався повністю видимим на екрані.
---     Зберігає позицію в налаштуваннях тільки в пам'яті (збереження на диск відбувається при зупинці перетягування).
 function DraggableHUD:moveTo(x, y)
     x = math.max(0, math.min(1 - self.width, x))
     y = math.max(0, math.min(1 - (self.height + self.headerHeight), y))
-
     self:setPosition(x, y)
-
     self.settings.hudPosX = x
     self.settings.hudPosY = y
 end
 
--- EN: Releases all GPU resources (overlay objects and icon overlays).
--- UA: Звільняє всі ресурси GPU (об'єкти оверлеїв та іконок).
 function DraggableHUD:delete()
     if self.backgroundOverlay then self.backgroundOverlay:delete() end
     if self.headerOverlay then self.headerOverlay:delete() end

--- a/src/hud/HUDRenderer.lua
+++ b/src/hud/HUDRenderer.lua
@@ -6,55 +6,54 @@
 --     а також для вимірювання ширини тексту. Використовується DraggableHUD та іншими HUD-компонентами.
 HUDRenderer = {}
 
--- EN: Predefined color constants used throughout HUD rendering.
--- UA: Заздалегідь визначені константи кольорів для рендерингу HUD.
+-- EN: Predefined color constants — industrial dark theme with amber accents.
+--     Dark olive background, warm white text, amber highlights.
+-- UA: Заздалегідь визначені константи кольорів — індустріальна темна тема з бурштиновими акцентами.
+--     Темно-оливковий фон, тепло-білий текст, бурштинові підсвічування.
 HUDRenderer.COLORS = {
-    BACKGROUND = {0, 0, 0, 0.7},      -- EN: Dark semi-transparent background / UA: Темний напівпрозорий фон
-    BORDER     = {1, 1, 1, 0.3},      -- EN: Light semi-transparent border / UA: Світла напівпрозора рамка
-    TEXT_WHITE  = {1, 1, 1, 1},       -- EN: White text / UA: Білий текст
-    TEXT_GREEN  = {0.2, 1, 0.2, 1},   -- EN: Green text (good/optimal status) / UA: Зелений текст (хороший/оптимальний стан)
-    TEXT_YELLOW = {1, 1, 0.2, 1},     -- EN: Yellow text (warning) / UA: Жовтий текст (попередження)
-    TEXT_RED    = {1, 0.2, 0.2, 1}    -- EN: Red text (critical/overload) / UA: Червоний текст (критичний/перевантаження)
+    BACKGROUND      = {0.04, 0.05, 0.03, 0.95},
+    HEADER          = {0.09, 0.07, 0.03, 1.00},
+    SURFACE         = {1.00, 1.00, 1.00, 0.04},
+    STATS_BG        = {0.00, 0.00, 0.00, 0.28},
+    BAR_BG          = {1.00, 1.00, 1.00, 0.07},
+    BAR_OPTIMAL     = {1.00, 1.00, 1.00, 0.42},
+    SECTION_LINE    = {1.00, 1.00, 1.00, 0.08},
+    SEPARATOR       = {1.00, 1.00, 1.00, 0.10},
+    ACCENT          = {0.83, 0.54, 0.04, 1.00},
+    ACCENT_DIM      = {0.83, 0.54, 0.04, 0.14},
+    TEXT_WHITE      = {0.91, 0.87, 0.78, 1.00},
+    TEXT_DIM        = {0.38, 0.36, 0.32, 1.00},
+    TEXT_GREEN      = {0.24, 0.72, 0.47, 1.00},
+    TEXT_YELLOW     = {0.91, 0.78, 0.25, 1.00},
+    TEXT_RED        = {0.89, 0.29, 0.29, 1.00},
+    TEXT_TEAL       = {0.60, 1.00, 0.80, 1.00},
+    BTN_DEFAULT     = {0.10, 0.10, 0.08, 1.00},
+    BTN_HOVER       = {0.20, 0.20, 0.16, 1.00},
+    BTN_PLUS_HOVER  = {0.06, 0.20, 0.10, 1.00},
+    BTN_MINUS_HOVER = {0.22, 0.06, 0.06, 1.00},
+    BTN_AUTO        = {0.05, 0.18, 0.09, 1.00},
+    BTN_RESET       = {0.20, 0.08, 0.03, 1.00},
+    BTN_SAVE        = {0.06, 0.12, 0.04, 1.00},
 }
 
--- EN: Size constants for layout calculations (all values in normalized screen coordinates).
--- UA: Константи розмірів для розрахунку розмітки (всі значення в нормалізованих координатах екрану).
 HUDRenderer.SIZES = {
-    PADDING      = 0.005,  -- EN: Internal padding around content / UA: Внутрішні відступи навколо контенту
-    BORDER_WIDTH = 0.002,  -- EN: Border thickness / UA: Товщина рамки
-    LINE_HEIGHT  = 0.015   -- EN: Text line height / UA: Висота рядка тексту
+    PADDING      = 0.005,
+    BORDER_WIDTH = 0.001,
+    LINE_HEIGHT  = 0.015
 }
 
--- EN: Renders text at the given screen position with the specified color, size, and alignment.
---     Resets text state (color, alignment, bold) to defaults after rendering.
--- UA: Відображає текст у заданій позиції екрану з вказаним кольором, розміром і вирівнюванням.
---     Скидає стан тексту (колір, вирівнювання, жирний) до значень за замовчуванням після відображення.
 function HUDRenderer.drawText(text, x, y, size, color, align)
     align = align or "left"
-
-    -- EN: Skip empty text to avoid unnecessary render calls.
-    -- UA: Пропускаємо порожній текст, щоб уникнути зайвих викликів рендерингу.
-    if not text or text == "" then
-        return
-    end
-
+    if not text or text == "" then return end
     setTextColor(color[1], color[2], color[3], color[4])
     setTextBold(true)
     setTextAlignment(RenderText["ALIGN_" .. string.upper(align)])
-
     renderText(x, y, size, text)
-
-    -- EN: Reset text rendering state to engine defaults after every draw call.
-    -- UA: Скидаємо стан рендерингу тексту до значень рушія після кожного виклику малювання.
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextBold(false)
     setTextColor(1, 1, 1, 1)
 end
 
--- EN: Calculates and returns the rendered width of a text string at the given font size.
---     Temporarily sets bold mode to match the rendering style used in drawText.
--- UA: Розраховує та повертає ширину відображуваного рядка тексту при заданому розмірі шрифту.
---     Тимчасово вмикає жирний шрифт, щоб відповідати стилю відображення в drawText.
 function HUDRenderer.getTextWidth(text, size)
     setTextBold(true)
     local width = getTextWidth(size, text)

--- a/src/logic/LoadCalculator.lua
+++ b/src/logic/LoadCalculator.lua
@@ -41,9 +41,41 @@ function LoadCalculator.new(modDirectory)
     
     -- Crop loss and productivity
     self.cropLoss = 0  -- EN: Current crop loss (%) / UA: Поточні втрати врожаю (%)
+    self.headerLoss = 0 -- EN: Header/speed-related crop loss (%) / UA: Втрати від швидкості на жатці (%)
     self.tonPerHour = 0  -- EN: Yield in T/h / UA: Продуктивність в Т/год
     self.litersPerHour = 0  -- EN: Yield in L/h / UA: Продуктивність в Л/год
     self.totalOutputMass = 0  -- EN: Total harvested mass / UA: Загальна маса зібраного врожаю
+
+    -- EN: Rotor plugging state machine.
+    --     A plug occurs when engine load stays at 130%+ for 10 consecutive seconds.
+    --     Once plugged, the combine is disabled for 12 seconds (clear time).
+    -- UA: Стан машини забивання ротора.
+    self.plugTimer = 0      -- EN: ms spent continuously at >=130% load / UA: мс безперервно при навантаженні >=130%
+    self.isPlugged = false  -- EN: True while combine is clearing a plug / UA: True поки комбайн очищує засмічення
+    self.pluggedTimer = 0   -- EN: ms remaining until plug is cleared / UA: мс що залишились до очищення засмічення
+
+    -- EN: Time-of-day moisture factor (cached every 60s to avoid per-tick env queries).
+    -- UA: Коефіцієнт вологості часу доби (кешується кожні 60с для уникнення запитів оточення кожен тік).
+    self.moistureFactor = 1.0
+    self.moistureLabel = ""   -- EN: Short label for HUD display / UA: Коротка мітка для HUD
+    self._moistureUpdateTimer = 0
+
+    -- EN: Session statistics — reset by the player via the Harvest Report panel.
+    -- UA: Статистика сесії — скидається гравцем через панель звіту про збирання.
+    self.session = {
+        startTime   = 0,
+        area        = 0,   -- ha
+        mass        = 0,   -- tonnes
+        loadSum     = 0,
+        loadCount   = 0,
+        lossSum     = 0,
+        lossCount   = 0,
+        hdrLossSum  = 0,
+        hdrLossCount= 0,
+        peakLoad    = 0,
+        plugCount   = 0,
+        active      = false,
+    }
     
     -- EN: Yield counters accumulation / UA: Накопичення продуктивності
     self.productivityMass = 0  -- EN: Accumulated mass (kg) / UA: Накопичена маса (кг)
@@ -286,10 +318,32 @@ function LoadCalculator:getBasePerformanceFromPower(vehicle)
     end
     
     if power and tonumber(power) > 0 then
-        local basePerf = tonumber(power) * coef
+        -- EN: Built-in throughput curve (exponent 0.75, reference 400hp) — used when no
+        --     CropThroughputConfig override is present for this crop.
+        --     Formula: basePerf = coef * (REF_HP^0.25) * (hp^0.75)
+        -- UA: Вбудована крива пропускної здатності (показник 0.75, еталон 400 к.с.) —
+        --     застосовується, коли немає перевизначення CropThroughputConfig для культури.
+        local REF_HP = 400.0
+        local hp = tonumber(power)
+        local basePerf = coef * (REF_HP ^ 0.25) * (hp ^ 0.75)
+
+        -- EN: CropThroughputConfig provides a per-crop power-law curve derived from two real-world
+        --     anchor points (280 hp = AEM Class 6 min, 750 hp = AEM Class 10 max).
+        --     When present, use  basePerf = A * hp^B  directly, which correctly places every
+        --     machine HP between those anchors on the right calibrated curve.
+        -- UA: CropThroughputConfig надає криву для кожної культури, виведену з двох реальних
+        --     опорних точок (280 к.с. = мінімум Class 6, 750 к.с. = максимум Class 10).
+        if CropThroughputConfig and CropThroughputConfig.getCurveParams then
+            local cropName = self.combineMemory and self.combineMemory.currentCrop
+            local params = CropThroughputConfig.getCurveParams(cropName)
+            if params then
+                basePerf = params.coef * (hp ^ params.exp)
+            end
+        end
+
         if rhm_Combine and rhm_Combine.debug then
-            print(string.format("RHM DEBUG: BasePerf Mass computed for %s (cat: %s, coef: %.3f): %d hp -> %.2f kg/s (%.1f t/h)", 
-                vehicle:getFullName(), category or "unknown", coef, power, basePerf, basePerf * 3.6))
+            print(string.format("RHM DEBUG: BasePerf Mass computed for %s (cat: %s, coef: %.3f): %d hp -> %.2f kg/s (%.1f t/h)",
+                vehicle:getFullName(), category or "unknown", coef, hp, basePerf, basePerf * 3.6))
         end
         return basePerf
     end
@@ -301,6 +355,282 @@ function LoadCalculator:getBasePerformanceFromPower(vehicle)
     end
     
     return 10.0  -- Default ~36 t/h
+end
+
+-- ============================================================================
+-- EN: Time-of-day moisture factor.
+--     Morning dew and evening humidity increase effective crop resistance,
+--     raising engine load and naturally slowing the machine down.
+--     Dry afternoon window (10am-5pm) = 1.0 baseline.
+--     Moisture label is set for HUD display when conditions are non-optimal.
+-- UA: Коефіцієнт вологості часу доби.
+-- ============================================================================
+function LoadCalculator:updateMoistureFactor(dt)
+    self._moistureUpdateTimer = (self._moistureUpdateTimer or 0) + dt
+    if self._moistureUpdateTimer < 60000 then return end  -- EN: Update every 60s / UA: Оновлення кожні 60с
+    self._moistureUpdateTimer = 0
+
+    if not g_currentMission or not g_currentMission.environment then
+        self.moistureFactor = 1.0
+        self.moistureLabel = ""
+        return
+    end
+
+    -- EN: dayTime is milliseconds since midnight. 24h = 86,400,000 ms.
+    -- UA: dayTime — мілісекунди від опівночі. 24 год = 86 400 000 мс.
+    local dayTime = g_currentMission.environment.currentDayTime or 0
+    local hour = dayTime / 3600000  -- EN: Convert to fractional hours / UA: Перетворюємо в дробові години
+
+    -- EN: Moisture windows (hour ranges):
+    --   22:00-06:00 = Night dew      → +12% crop resistance
+    --   06:00-09:00 = Morning dew    → +15% crop resistance (peak wet window)
+    --   09:00-10:30 = Drying out     → +5%
+    --   10:30-17:00 = Optimal window → 0% (factor 1.0)
+    --   17:00-19:00 = Evening rise   → +5%
+    --   19:00-22:00 = Evening dew    → +10%
+    -- UA: Вікна вологості (діапазони годин):
+    local factor, label
+    if hour >= 6.0 and hour < 9.0 then
+        factor = 1.15
+        label  = "Morning Dew +15%"
+    elseif hour >= 9.0 and hour < 10.5 then
+        factor = 1.05
+        label  = "Drying +5%"
+    elseif hour >= 10.5 and hour < 17.0 then
+        factor = 1.0
+        label  = ""
+    elseif hour >= 17.0 and hour < 19.0 then
+        factor = 1.05
+        label  = "Humidity +5%"
+    elseif hour >= 19.0 and hour < 22.0 then
+        factor = 1.10
+        label  = "Eve. Dew +10%"
+    else
+        -- EN: Night (22:00-06:00) / UA: Ніч (22:00-06:00)
+        factor = 1.12
+        label  = "Night Dew +12%"
+    end
+
+    self.moistureFactor = factor
+    self.moistureLabel  = label
+end
+
+-- ============================================================================
+-- EN: Header loss — crop loss due to travel speed at the cutter bar.
+--     Grain knocked off heads or shattered pods at high speed.
+--     Conservative values: <1% up to 6 mph (9.7 km/h), escalating above 8 mph.
+--     Crop-specific multipliers: canola/soybean are most vulnerable to shattering.
+-- UA: Втрати на жатці — втрати врожаю через швидкість руху у зоні жатки.
+-- ============================================================================
+LoadCalculator.HEADER_LOSS_CROP_FACTORS = {
+    canola    = 2.0,   -- EN: Pod shatter very sensitive / UA: Дуже чутливий до розтріскування стручків
+    soybean   = 1.8,   -- EN: Pod shatter risk / UA: Ризик розтріскування стручків
+    sunflower = 1.5,   -- EN: Head shatter / UA: Розтріскування кошика
+    oat       = 1.2,   -- EN: Loose hull / UA: Слабкий лушпій
+    rice      = 1.1,   -- EN: Shattering at tip / UA: Розтріскування на кінчику
+    wheat     = 1.0,
+    barley    = 1.0,
+    sorghum   = 0.8,
+    corn      = 0.25,  -- EN: Kernels well-protected in husk / UA: Зерна добре захищені в лушпинні
+    legume    = 1.6,   -- EN: Bean/pea pod shatter / UA: Розтріскування стручків бобів/гороху
+}
+
+function LoadCalculator:calculateHeaderLoss(vehicle)
+    if not vehicle then return 0 end
+
+    -- EN: Header loss only applies when actively cutting (not forage — handled separately).
+    -- UA: Втрати на жатці застосовуються лише при активному косінні (не форажні).
+    if self.combineMemory and self.combineMemory.machineType == "forage" then
+        self.headerLoss = 0
+        return 0
+    end
+
+    local speed = vehicle:getLastSpeed()  -- EN: km/h / UA: км/год
+
+    -- EN: 9.65 km/h = 6 mph (threshold where header loss begins).
+    --     12.87 km/h = 8 mph (threshold where loss escalates sharply).
+    -- UA: 9.65 км/год = 6 миль/год; 12.87 км/год = 8 миль/год.
+    local THRESH_6MPH = 9.65
+    if speed <= THRESH_6MPH then
+        self.headerLoss = 0
+        return 0
+    end
+
+    -- EN: Crop-specific shattering factor (defaults to wheat baseline = 1.0).
+    -- UA: Коефіцієнт чутливості культури до обсипання (за замовчуванням пшениця = 1.0).
+    local cropFactor = 1.0
+    if self.combineMemory and self.combineMemory.currentCrop then
+        local key = string.lower(self.combineMemory.currentCrop)
+        -- EN: Strip suffixes like "_windrow", "_forage" etc. for lookup.
+        -- UA: Обрізаємо суфікси типу "_windrow", "_forage" тощо для пошуку.
+        for k, v in pairs(LoadCalculator.HEADER_LOSS_CROP_FACTORS) do
+            if key == k or key:find(k, 1, true) then
+                cropFactor = v
+                break
+            end
+        end
+    end
+
+    -- EN: Gentle power-law curve. At 8 mph (12.87 km/h) wheat gets ~1.5%.
+    --     Beyond 8 mph it escalates: at 10 mph (~16 km/h) wheat gets ~3.5%.
+    --     All values capped at 8% to stay conservative.
+    -- UA: М'яка крива степеневого закону. При 8 миль/год (12.87 км/год) пшениця дає ~1.5%.
+    local excessSpeed = speed - THRESH_6MPH  -- EN: km/h above 6mph threshold
+    local rawLoss = (excessSpeed ^ 1.35) * 0.28 * cropFactor
+    self.headerLoss = math.min(8.0, rawLoss)
+    return self.headerLoss
+end
+
+-- ============================================================================
+-- EN: Plug state machine update. Called every tick from rhm_Combine:onUpdateTick.
+--     Returns true if the plug state CHANGED this tick (for event/notification use).
+-- UA: Оновлення стану засмічення ротора. Повертає true якщо стан змінився.
+-- ============================================================================
+function LoadCalculator:updatePlugState(dt)
+    local changed = false
+    if self.isPlugged then
+        -- EN: Counting down clear timer.
+        -- UA: Відлік таймера очищення.
+        self.pluggedTimer = self.pluggedTimer - dt
+        if self.pluggedTimer <= 0 then
+            self.isPlugged    = false
+            self.pluggedTimer = 0
+            self.plugTimer    = 0
+            changed = true
+        end
+    else
+        -- EN: Check if engine load has been at 130%+ long enough to cause a plug.
+        --     130% = engineLoad >= 1.30
+        -- UA: Перевіряємо чи навантаження 130%+ тривало достатньо довго для засмічення.
+        if self.engineLoad >= 1.30 then
+            self.plugTimer = (self.plugTimer or 0) + dt
+            if self.plugTimer >= 10000 then  -- EN: 10 seconds / UA: 10 секунд
+                self.isPlugged    = true
+                self.pluggedTimer = 12000   -- EN: 12 second clear time / UA: 12 секунд на очищення
+                self.plugTimer    = 0
+                self.session.plugCount = (self.session.plugCount or 0) + 1
+                changed = true
+            end
+        else
+            -- EN: Load dropped below threshold — reset the timer.
+            -- UA: Навантаження впало нижче порогу — скидаємо таймер.
+            self.plugTimer = 0
+        end
+    end
+    return changed
+end
+
+-- ============================================================================
+-- EN: Session tracking helpers.
+-- UA: Допоміжні функції для відстеження статистики сесії.
+-- ============================================================================
+function LoadCalculator:startSession()
+    self.session = {
+        startTime    = g_currentMission and g_currentMission.time or 0,
+        area         = 0,
+        mass         = 0,
+        loadSum      = 0,
+        loadCount    = 0,
+        lossSum      = 0,
+        lossCount    = 0,
+        hdrLossSum   = 0,
+        hdrLossCount = 0,
+        peakLoad     = 0,
+        plugCount    = 0,
+        active       = true,
+    }
+end
+
+function LoadCalculator:resetSession()
+    self:startSession()
+end
+
+function LoadCalculator:updateSession(massKg, areaM2, cropLoss, headerLoss)
+    if not self.session or not self.session.active then return end
+    local load = self.engineLoad * 100
+
+    self.session.mass  = (self.session.mass  or 0) + massKg / 1000
+    self.session.area  = (self.session.area  or 0) + areaM2 / 10000
+
+    if load > 0 then
+        self.session.loadSum   = (self.session.loadSum   or 0) + load
+        self.session.loadCount = (self.session.loadCount or 0) + 1
+        if load > (self.session.peakLoad or 0) then
+            self.session.peakLoad = load
+        end
+    end
+    if cropLoss > 0 then
+        self.session.lossSum   = (self.session.lossSum   or 0) + cropLoss
+        self.session.lossCount = (self.session.lossCount or 0) + 1
+    end
+    if headerLoss > 0 then
+        self.session.hdrLossSum   = (self.session.hdrLossSum   or 0) + headerLoss
+        self.session.hdrLossCount = (self.session.hdrLossCount or 0) + 1
+    end
+end
+
+-- EN: Returns a formatted summary table for the Harvest Report panel.
+-- UA: Повертає форматовану таблицю підсумків для панелі звіту про збирання.
+function LoadCalculator:getSessionSummary(unitSystem)
+    local s = self.session or {}
+    local avgLoad   = s.loadCount   > 0 and (s.loadSum   / s.loadCount)    or 0
+    local avgLoss   = s.lossCount   > 0 and (s.lossSum   / s.lossCount)    or 0
+    local avgHdrLoss= s.hdrLossCount> 0 and (s.hdrLossSum/ s.hdrLossCount) or 0
+
+    -- EN: Elapsed time in seconds (game time, not real time).
+    -- UA: Час сесії в секундах (ігровий час, не реальний).
+    local elapsed = 0
+    if s.startTime and g_currentMission then
+        elapsed = math.max(0, (g_currentMission.time - s.startTime) / 1000)
+    end
+    local elapsedMin = math.floor(elapsed / 60)
+
+    -- EN: Session efficiency grade (starts at 100, penalties applied).
+    -- UA: Оцінка ефективності сесії (починаємо з 100, застосовуємо штрафи).
+    local score = 100
+    score = score - avgLoss    * 5.0   -- EN: -5 pts per 1% avg threshing loss
+    score = score - avgHdrLoss * 3.0   -- EN: -3 pts per 1% avg header loss
+    score = score - (s.plugCount or 0) * 10  -- EN: -10 pts per plug
+    if avgLoad > 0 and avgLoad < 70 then
+        score = score - math.max(0, (70 - avgLoad) / 5) * 3  -- EN: Under-utilization penalty
+    end
+    score = math.max(0, math.min(100, score))
+
+    local grade
+    if     score >= 90 then grade = "A"
+    elseif score >= 80 then grade = "B"
+    elseif score >= 70 then grade = "C"
+    elseif score >= 60 then grade = "D"
+    else                    grade = "F"
+    end
+    -- EN: Add +/- modifier within each letter band
+    local mod = score % 10
+    if mod >= 7 then grade = grade .. "+"
+    elseif mod < 3 and grade ~= "F" then grade = grade .. "-"
+    end
+
+    -- EN: Convert area + mass to active unit system.
+    local areaStr, massStr
+    if unitSystem == 2 or unitSystem == 3 then
+        areaStr = string.format("%.1f ac", (s.area or 0) * 2.47105)
+        massStr = string.format("%.1f t",  (s.mass or 0) * 1.10231)
+    else
+        areaStr = string.format("%.1f ha", s.area or 0)
+        massStr = string.format("%.1f t",  s.mass or 0)
+    end
+
+    return {
+        time        = string.format("%d min", elapsedMin),
+        area        = areaStr,
+        mass        = massStr,
+        avgLoad     = string.format("%.0f%%", avgLoad),
+        peakLoad    = string.format("%.0f%%", s.peakLoad or 0),
+        avgLoss     = string.format("%.1f%%", avgLoss),
+        avgHdrLoss  = string.format("%.1f%%", avgHdrLoss),
+        plugs       = tostring(s.plugCount or 0),
+        grade       = grade,
+        score       = math.floor(score),
+    }
 end
 
 ---EN: Updates load calculation variables / UA: Оновлює дані для розрахунку навантаження
@@ -459,10 +789,10 @@ function LoadCalculator:calculateEngineLoad(vehicle)
                          or currentFruitTypeName:find("GREENBEAN")
                          
         if not isRootOrVeg then
-            cropFactor = cropFactor * 0.25  -- EN: Standard windrows (Wheat, Barley, etc.)
+            cropFactor = cropFactor * 0.75  -- EN: Standard windrows (Wheat, Barley, etc.)
         end
     elseif isForageCutter then
-        cropFactor = cropFactor * 0.75  -- EN: Forage harvesters (silage/direct cut) / UA: Кормозбиральні комбайни (силос/пряме косіння)
+        cropFactor = cropFactor * 0.80  -- EN: Forage harvesters (silage/direct cut) / UA: Кормозбиральні комбайни (силос/пряме косіння)
     end
 
     -- --- [RHM DEBUG: INFO LOG] ---
@@ -474,8 +804,10 @@ function LoadCalculator:calculateEngineLoad(vehicle)
     
     -- EN: Calculate RAW average mass intake per second / UA: Розраховуємо RAW середню масу за секунду (кг/с)
     -- EN: Uses accumulatedMass over the target distance/time / UA: Використовуємо accumulatedMass
+    -- EN: Apply time-of-day moisture factor — wet crops require more power to thresh and separate.
+    -- UA: Застосовуємо коефіцієнт вологості — вологі культури потребують більше потужності.
     local safeTime = math.max(100, self.currentTime) -- Protect against division by zero
-    local rawAvgMass = (self.loadAccumulatedMass or 0) * (1000 / safeTime) * cropFactor
+    local rawAvgMass = (self.loadAccumulatedMass or 0) * (1000 / safeTime) * cropFactor * (self.moistureFactor or 1.0)
     
     -- ADAPTIVE SMOOTHING
     local loadRatio = self.currentAvgMass / math.max(0.01, self.basePerfMass)
@@ -510,7 +842,7 @@ end
 function LoadCalculator:calculateSpeedLimit(vehicle)
     if self.currentAvgMass == 0 then
         -- EN: If not harvesting, return to vanilla working speed / UA: Якщо не збираємо, повертаємось до ванільної робочої швидкості
-        local target = self.vanillaWorkingSpeed or 10.0
+        local target = self.genuineSpeedLimit > 0 and self.genuineSpeedLimit or 10.0
         if self.speedLimit > target then
             self.speedLimit = math.max(target, self.speedLimit - 0.5)
         elseif self.speedLimit < target then
@@ -519,67 +851,41 @@ function LoadCalculator:calculateSpeedLimit(vehicle)
         return
     end
     
-    local currentSpeed = vehicle.lastSpeedReal * 3600 
-    local speedKmh = math.max(1.0, currentSpeed)
-    if currentSpeed < 1.0 and self.currentAvgMass > (self.basePerfMass * 0.1) then
-        speedKmh = math.max(2.0, self.speedLimit)
+    local powerBoost = 0
+    local targetLoad = 0.95
+    if self.combineMemory and self.combineMemory.currentSettings and self.combineMemory.currentSettings.targetEngineLoad then
+        targetLoad = self.combineMemory.currentSettings.targetEngineLoad / 100.0
     end
     
-    local powerBoost = 0
     if g_realisticHarvestManager and g_realisticHarvestManager.settings then
         powerBoost = g_realisticHarvestManager.settings:getPowerBoost()
     end
+    
     local maxAvgMass = (1 + 0.01 * powerBoost) * self.basePerfMass * (self.settingsEfficiency or 1.0)
     if maxAvgMass <= 0.01 then return end
     
     local loadRatio = self.currentAvgMass / maxAvgMass
-    local rawLoadRatio = (self.rawAvgMass or self.currentAvgMass) / maxAvgMass
+
+    -- EN: Calculate error between target and current load
+    -- UA: Розраховуємо різницю між цільовим і реальним навантаженням
+    local difference = targetLoad - loadRatio
     
-    local targetLoad = 0.85
-    local idealSpeed = self.genuineSpeedLimit
-    
-    if loadRatio > 0.05 then 
-        idealSpeed = speedKmh * (targetLoad / loadRatio)
-    end
-    idealSpeed = math.min(self.genuineSpeedLimit, math.max(2.0, idealSpeed))
-    
-    local alpha = 0.1 
-    local controlZone = "NORMAL"
-    
-    if rawLoadRatio > 1.25 then
-        alpha = 1.0 -- PANIC
-        controlZone = "PANIC"
-        local emergencyIdeal = math.min(speedKmh, self.speedLimit) * (targetLoad / rawLoadRatio)
-        idealSpeed = math.min(idealSpeed, math.max(2.0, emergencyIdeal))
-    elseif rawLoadRatio > 1.10 then
-        alpha = 0.6 -- HARD BRAKE
-        controlZone = "HARD_BRAKE"
-        local hardbrakeIdeal = math.min(speedKmh, self.speedLimit) * (targetLoad / rawLoadRatio)
-        idealSpeed = math.min(idealSpeed, math.max(2.0, hardbrakeIdeal))
-    elseif loadRatio >= 0.85 and loadRatio <= 0.95 then
-        alpha = 0.02 -- DEADBAND
-        controlZone = "LOCKED"
-    elseif loadRatio < 0.85 then
-        if loadRatio < 0.50 then
-            alpha = self.isPickup and 0.15 or 0.40 -- EN: Slow down pickup accel / UA: Повільне прискорення підбирача
-            controlZone = "ACCEL_FAST"
-        elseif loadRatio < 0.75 then
-            alpha = self.isPickup and 0.10 or 0.25 
-            controlZone = "ACCEL_MED"
-        else
-            alpha = self.isPickup and 0.05 or 0.15 
-            controlZone = "ACCEL_SLOW"
-        end
+    -- EN: Proportional adjustment: hard brake on overload, smooth acceleration on underload
+    -- UA: Пропорційне регулювання: швидке гальмування при перевантаженні, плавний розгін
+    local step = difference * 2.0
+    if difference < 0 then
+        step = difference * 5.0 -- EN: Panic brake / UA: Екстренне скидання швидкості при забиванні
     end
     
-    local diff = idealSpeed - self.speedLimit
-    local maxStep = 1.0
-    if controlZone == "PANIC" then maxStep = 10.0 end
-    if controlZone == "HARD_BRAKE" then maxStep = 5.0 end
+    -- EN: Limit speed jump to avoid jittering
+    -- UA: Обмежуємо максимальний стрибок швидкості за один тік, щоб уникнути ривків
+    step = math.max(-3.0, math.min(1.0, step))
     
-    local step = diff * alpha
-    step = math.clamp(step, -maxStep, maxStep)
     self.speedLimit = self.speedLimit + step
+
+    -- EN: Clamp speed within safe bounds
+    -- UA: Обмеження швидкості: не менше 2 км/год і не більше оригінального ліміту гри
+    self.speedLimit = math.max(2.0, math.min(self.genuineSpeedLimit, self.speedLimit))
 end
 
 ---EN: Returns current engine load factor / UA: Повертає поточне навантаження двигуна
@@ -599,7 +905,8 @@ function LoadCalculator:setGenuineSpeedLimit(limit, maxCap)
     self.speedLimit = limit
 end
 
----EN: Fully resets accumulated internal data variables / UA: Повністю очищує змінні бази даних
+---EN: Fully resets accumulated internal data variables (does NOT reset session stats).
+-- UA: Повністю очищує змінні бази даних (НЕ скидає статистику сесії).
 function LoadCalculator:reset()
     self.totalDistance = 0
     self.totalArea = 0
@@ -607,6 +914,9 @@ function LoadCalculator:reset()
     self.currentAvgMass = 0
     self.engineLoad = 0
     self.cropLoss = 0
+    self.headerLoss = 0
+    self.plugTimer = 0
+    -- EN: Do NOT clear isPlugged or pluggedTimer here — they persist until the clear timer expires.
     self.speedLimit = self.vanillaWorkingSpeed or (self.genuineSpeedLimit > 0 and self.genuineSpeedLimit or 15)
     self.productivityMass = 0
     self.productivityLiters = 0
@@ -631,23 +941,37 @@ end
 function LoadCalculator:calculateCropLoss()
     if not g_realisticHarvestManager or not g_realisticHarvestManager.settings then return 0 end
     if not g_realisticHarvestManager.settings.enableCropLoss then return 0 end
+
+    -- EN: Forage harvesters (silage cutters) have no true loss mechanic — the only way
+    --     crop is lost is if the spout discharge misses the trailer, which is an operator
+    --     issue unrelated to machine settings. Exclude loss for forage machines entirely.
+    -- UA: Кормозбиральні комбайни (силосоріза) не мають реального механізму втрат —
+    --     втрати можливі тільки якщо розвантаження міне причіп (помилка оператора).
+    if self.combineMemory and self.combineMemory.machineType == "forage" then
+        self.cropLoss = 0
+        return 0
+    end
     
-    local activeEfficiency = self.settingsEfficiency or 1.0
-    local shieldBonus = math.max(0, activeEfficiency - 1.0)
-    local lossThreshold = 0.95 + shieldBonus
+    local lossMultiplier = g_realisticHarvestManager.settings:getLossMultiplier()
     
-    if self.engineLoad > lossThreshold then
-        local overload = self.engineLoad - lossThreshold
-        local lossMultiplier = g_realisticHarvestManager.settings:getLossMultiplier()
-        local loss = 0
-        if overload <= 0.10 then
-            loss = overload * 40 * lossMultiplier
-        elseif overload <= 0.20 then
-            loss = (4.0 + (overload - 0.10) * 80) * lossMultiplier
-        else
-            loss = (12.0 + (overload - 0.20) * 150) * lossMultiplier
+    -- EN: Losses start smoothly from 80% engine load
+    -- UA: Втрати починаються плавно з 80% завантаження
+    if self.engineLoad > 0.80 then
+        local overload = self.engineLoad - 0.80
+        -- UA: Прогресивна крива (експонента): 
+        -- При 80% (overload=0) -> 0% втрат
+        -- При 90% (overload=0.1) -> 0.5% (мізерні втрати)
+        -- При 100% (overload=0.2) -> 2.0% (допустимі втрати)
+        -- При 110% (overload=0.3) -> 4.5% (пік продуктивності)
+        -- При 130% (overload=0.5) -> 12.5% (величезні втрати)
+        local rawLoss = (overload * overload) * 50
+        
+        -- UA: Різке зростання, якщо завантаження перевищило 110% (забита молотарка)
+        if self.engineLoad > 1.10 then
+            rawLoss = rawLoss + ((self.engineLoad - 1.10) * 100)
         end
-        self.cropLoss = math.min(loss, 50) 
+        
+        self.cropLoss = math.min(rawLoss * lossMultiplier, 50) 
     else
         self.cropLoss = 0
     end

--- a/src/main.lua
+++ b/src/main.lua
@@ -30,6 +30,7 @@ source(modDirectory .. "src/data/CombineSettingsDatabase.lua")
 source(modDirectory .. "src/settings/ProfileManager.lua")
 source(modDirectory .. "src/settings/CombineMemory.lua")
 source(modDirectory .. "src/network/CombineSettingsEvent.lua")
+source(modDirectory .. "src/config/CropThroughputConfig.lua")
 source(modDirectory .. "src/logic/LoadCalculator.lua")
 source(modDirectory .. "src/rhm_Combine.lua")
 -- EN: CRITICAL: rhm_Cutter must be loaded AFTER rhm_Combine for independent header launch to work.
@@ -66,6 +67,12 @@ local function loadedMission(mission, node)
     -- UA: Безпечно ініціалізуємо коефіцієнти бушелів (FruitType доступний тільки після завантаження місії).
     if UnitConverter and UnitConverter.initBushelCoefficients then
         UnitConverter.initBushelCoefficients()
+    end
+
+    -- EN: Load per-crop throughput overrides from modSettings XML (if present).
+    -- UA: Завантажуємо перевизначення продуктивності культур з modSettings XML (якщо є).
+    if CropThroughputConfig and CropThroughputConfig.load then
+        CropThroughputConfig.load()
     end
 
     rhm:onMissionLoaded()

--- a/src/network/CombineSettingsEvent.lua
+++ b/src/network/CombineSettingsEvent.lua
@@ -1,7 +1,9 @@
--- EN: Network event for syncing combine settings changes (fan, rotor, sieve, feeder) from
+-- EN: Network event for syncing combine settings changes (fan, rotor, sieve, concave/feeder) from
 --     the client GUI to the server, and from the server back to all other clients.
 --     Supports two modes: single-parameter update or full profile apply.
--- UA: Мережева подія для синхронізації змін налаштувань комбайна (вентилятор, ротор, решета, подача)
+--     NOTE: The 5th slot in fullSettings is called "slot5" internally and maps to either
+--           "concave" (grain) or "feeder" (forage/root/cotton) based on the machine type.
+-- UA: Мережева подія для синхронізації змін налаштувань комбайна (вентилятор, ротор, решета, деко/подача)
 --     від GUI клієнта до сервера, і від сервера до всіх інших клієнтів.
 --     Підтримує два режими: оновлення одного параметру або застосування повного профілю.
 CombineSettingsEvent = {}
@@ -35,14 +37,17 @@ function CombineSettingsEvent:readStream(streamId, connection)
     self.isFullProfile = streamReadBool(streamId)
 
     if self.isFullProfile then
-        -- EN: Full profile mode: read all 5 parameter values.
-        -- UA: Режим повного профілю: зчитуємо всі 5 значень параметрів.
+        -- EN: Full profile mode: read all 5 parameter values + upgrade level.
+        --     slot5 carries either "concave" (grain) or "feeder" (forage/root/cotton).
+        -- UA: Режим повного профілю: зчитуємо всі 5 значень параметрів + рівень апгрейду.
         self.fullSettings = {}
         self.fullSettings.fan = streamReadUInt8(streamId)
         self.fullSettings.rotor = streamReadUInt8(streamId)
         self.fullSettings.upperSieve = streamReadUInt8(streamId)
         self.fullSettings.lowerSieve = streamReadUInt8(streamId)
-        self.fullSettings.feeder = streamReadUInt8(streamId)
+        self.fullSettings.slot5 = streamReadUInt8(streamId)        -- concave or feeder
+        self.fullSettings.targetEngineLoad = streamReadUInt8(streamId)
+        self.fullSettings.upgradeLevel = streamReadUInt8(streamId)
     else
         -- EN: Single parameter mode: read parameter name and its value.
         -- UA: Режим одного параметру: зчитуємо назву параметру і його значення.
@@ -59,13 +64,16 @@ function CombineSettingsEvent:writeStream(streamId, connection)
     streamWriteBool(streamId, self.isFullProfile)
 
     if self.isFullProfile then
-        -- EN: Write all 5 parameter values for a full profile transfer.
-        -- UA: Записуємо всі 5 значень параметрів для передачі повного профілю.
+        -- EN: Write all 5 parameter values + upgrade level for a full profile transfer.
+        --     slot5 carries either "concave" (grain) or "feeder" (forage/root/cotton).
+        -- UA: Записуємо всі 5 значень параметрів + рівень апгрейду для передачі повного профілю.
         streamWriteUInt8(streamId, self.fullSettings.fan or 50)
         streamWriteUInt8(streamId, self.fullSettings.rotor or 50)
         streamWriteUInt8(streamId, self.fullSettings.upperSieve or 50)
         streamWriteUInt8(streamId, self.fullSettings.lowerSieve or 50)
-        streamWriteUInt8(streamId, self.fullSettings.feeder or 50)
+        streamWriteUInt8(streamId, self.fullSettings.slot5 or 50)   -- concave or feeder
+        streamWriteUInt8(streamId, self.fullSettings.targetEngineLoad or 95)
+        streamWriteUInt8(streamId, self.fullSettings.upgradeLevel or 0)
     else
         -- EN: Write single parameter name and value.
         -- UA: Записуємо назву та значення одного параметру.
@@ -82,6 +90,16 @@ function CombineSettingsEvent:run(connection)
     if self.vehicle and self.vehicle:getIsSynchronized() and self.vehicle.spec_rhm_Combine and self.vehicle.spec_rhm_Combine.combineMemory then
         local mem = self.vehicle.spec_rhm_Combine.combineMemory
 
+        -- EN: Helper: apply slot5 value to the correct key (concave for grain, feeder for others).
+        -- UA: Допоміжна: застосовуємо значення slot5 до правильного ключа.
+        local function applySlot5(memory, val)
+            if memory.currentSettings.concave ~= nil then
+                memory.currentSettings.concave = val  -- grain combines
+            elseif memory.currentSettings.feeder ~= nil then
+                memory.currentSettings.feeder = val   -- forage/root/cotton
+            end
+        end
+
         if g_server ~= nil then
             if self.isFullProfile then
                 -- EN: Apply a complete user preset profile to the combine memory.
@@ -90,14 +108,25 @@ function CombineSettingsEvent:run(connection)
                 mem.currentSettings.rotor = self.fullSettings.rotor
                 mem.currentSettings.upperSieve = self.fullSettings.upperSieve
                 mem.currentSettings.lowerSieve = self.fullSettings.lowerSieve
-                mem.currentSettings.feeder = self.fullSettings.feeder
+                applySlot5(mem, self.fullSettings.slot5 or 50)
+                mem.currentSettings.targetEngineLoad = self.fullSettings.targetEngineLoad
+                if self.fullSettings.upgradeLevel then
+                    mem.upgradeLevel = self.fullSettings.upgradeLevel
+                end
                 mem.autoSwitchEnabled = false
                 mem.mode = "MANUAL"
                 if RHM_Debug and RHM_Debug.isEnabled("Network") then
                     print("RHM: [Sync] Received full user profile settings via network")
                 end
             else
-                if self.parameter == "AUTO_SET" then
+                if self.parameter == "UPGRADE_LEVEL" then
+                    -- EN: Client purchased an upgrade — update level on server and broadcast.
+                    -- UA: Клієнт придбав апгрейд — оновлюємо рівень на сервері та транслюємо.
+                    mem.upgradeLevel = math.max(mem.upgradeLevel or 0, math.floor(self.value))
+                    if RHM_Debug and RHM_Debug.isEnabled("Network") then
+                        print(string.format("RHM: [Sync] Upgrade level set to %d", mem.upgradeLevel))
+                    end
+                elseif self.parameter == "AUTO_SET" then
                     -- EN: Client requested AUTO mode — configure optimal settings for current crop.
                     -- UA: Клієнт запросив AUTO режим — налаштовуємо оптимальні значення для поточної культури.
                     mem.autoSwitchEnabled = true
@@ -128,9 +157,12 @@ function CombineSettingsEvent:run(connection)
                     -- EN: Apply a single parameter change (e.g. "fan" = 65).
                     -- UA: Застосовуємо зміну одного параметру (наприклад "fan" = 65).
                     if mem.currentSettings[self.parameter] ~= nil then
-                        mem.currentSettings[self.parameter] = math.max(0, math.min(100, self.value))
-                        mem.autoSwitchEnabled = false
-                        mem.mode = "MANUAL"
+                        local maxVal = self.parameter == "targetEngineLoad" and 110 or 100
+                        mem.currentSettings[self.parameter] = math.max(0, math.min(maxVal, self.value))
+                        if self.parameter ~= "targetEngineLoad" then
+                            mem.autoSwitchEnabled = false
+                            mem.mode = "MANUAL"
+                        end
                         if RHM_Debug and RHM_Debug.isEnabled("Network") then
                             print(string.format("RHM: [Sync] Received parameter update: %s = %d", self.parameter, self.value))
                         end
@@ -139,12 +171,15 @@ function CombineSettingsEvent:run(connection)
             end
 
             -- EN: Server always broadcasts the full state so clients sync perfectly without duplicate calculations.
+            --     slot5 carries concave (grain) or feeder (forage/root/cotton) dynamically.
             local fullSettings = {
                 fan = mem.currentSettings.fan,
                 rotor = mem.currentSettings.rotor,
                 upperSieve = mem.currentSettings.upperSieve,
                 lowerSieve = mem.currentSettings.lowerSieve,
-                feeder = mem.currentSettings.feeder
+                slot5 = mem.currentSettings.concave or mem.currentSettings.feeder or 50,
+                targetEngineLoad = mem.currentSettings.targetEngineLoad,
+                upgradeLevel = mem.upgradeLevel or 0,
             }
             g_server:broadcastEvent(CombineSettingsEvent.new(self.vehicle, "", 0, true, fullSettings), nil, connection, self.vehicle)
             local spec = self.vehicle.spec_rhm_Combine
@@ -162,15 +197,24 @@ function CombineSettingsEvent:run(connection)
                 mem.currentSettings.rotor = self.fullSettings.rotor
                 mem.currentSettings.upperSieve = self.fullSettings.upperSieve
                 mem.currentSettings.lowerSieve = self.fullSettings.lowerSieve
-                mem.currentSettings.feeder = self.fullSettings.feeder
+                applySlot5(mem, self.fullSettings.slot5 or 50)
+                mem.currentSettings.targetEngineLoad = self.fullSettings.targetEngineLoad
+                if self.fullSettings.upgradeLevel then
+                    mem.upgradeLevel = self.fullSettings.upgradeLevel
+                end
+            elseif self.parameter == "UPGRADE_LEVEL" then
+                mem.upgradeLevel = math.max(mem.upgradeLevel or 0, math.floor(self.value))
             elseif self.parameter == "AUTO_MODE" then
                 mem.autoSwitchEnabled = (self.value == 1)
                 mem.mode = mem.autoSwitchEnabled and "AUTO" or "MANUAL"
             elseif self.parameter ~= "AUTO_SET" and self.parameter ~= "RESET_SET" then
                 if mem.currentSettings[self.parameter] ~= nil then
-                    mem.currentSettings[self.parameter] = math.max(0, math.min(100, self.value))
-                    mem.autoSwitchEnabled = false
-                    mem.mode = "MANUAL"
+                    local maxVal = self.parameter == "targetEngineLoad" and 110 or 100
+                    mem.currentSettings[self.parameter] = math.max(0, math.min(maxVal, self.value))
+                    if self.parameter ~= "targetEngineLoad" then
+                        mem.autoSwitchEnabled = false
+                        mem.mode = "MANUAL"
+                    end
                 end
             end
         end

--- a/src/rhm_Combine.lua
+++ b/src/rhm_Combine.lua
@@ -58,14 +58,16 @@ end
 -- UA: Реєструє шляхи XML для конфігурації засобу (XML магазину/modDesc). Зберігає налаштування комбайна для кожного засобу.
 function rhm_Combine.registerXMLPaths(schema, basePath)
     local cur = basePath .. ".combineMemory.current"
-    schema:register(XMLValueType.STRING, cur .. "#mode",        "Combine settings mode", "AUTO")
-    schema:register(XMLValueType.STRING, cur .. "#currentCrop", "Current crop", "")
-    schema:register(XMLValueType.BOOL,   cur .. "#autoSwitch",  "Auto switch enabled", true)
-    schema:register(XMLValueType.INT,    cur .. "#fan",         "Fan", 50)
-    schema:register(XMLValueType.INT,    cur .. "#upperSieve",  "Upper sieve", 50)
-    schema:register(XMLValueType.INT,    cur .. "#lowerSieve",  "Lower sieve", 50)
-    schema:register(XMLValueType.INT,    cur .. "#rotor",       "Rotor", 50)
-    schema:register(XMLValueType.INT,    cur .. "#feeder",      "Feeder", 50)
+    schema:register(XMLValueType.STRING, cur .. "#mode",         "Combine settings mode", "AUTO")
+    schema:register(XMLValueType.STRING, cur .. "#currentCrop",  "Current crop", "")
+    schema:register(XMLValueType.BOOL,   cur .. "#autoSwitch",   "Auto switch enabled", true)
+    schema:register(XMLValueType.INT,    cur .. "#fan",          "Fan", 50)
+    schema:register(XMLValueType.INT,    cur .. "#upperSieve",   "Upper sieve", 50)
+    schema:register(XMLValueType.INT,    cur .. "#lowerSieve",   "Lower sieve", 50)
+    schema:register(XMLValueType.INT,    cur .. "#rotor",        "Rotor", 50)
+    schema:register(XMLValueType.INT,    cur .. "#concave",      "Concave gap (grain) / Feed roll (others)", 50)
+    schema:register(XMLValueType.INT,    cur .. "#feeder",       "Feeder (legacy / forage+root+cotton)", 50)
+    schema:register(XMLValueType.INT,    cur .. "#upgradeLevel", "Upgrade tier (0-4)", 0)
 end
 
 -- EN: Mirrors registerXMLPaths for the savegame vehicles.xml schema.
@@ -339,12 +341,20 @@ function rhm_Combine:onLoad(savegame)
         speed = 0,
         load = 0,
         cropLoss = 0,
+        headerLoss = 0,        -- EN: Speed-related header loss (%) / UA: Втрати від швидкості на жатці (%)
         tonPerHour = 0,
         litersPerHour = 0,
         yield = 0,
         recommendedSpeed = 0,  -- EN: Updated by server tick, synced to clients / UA: Оновлюється сервером, синхронізується на клієнти
-        overloadLevel = 0      -- EN: 0=normal, 1=HIGH (120%+), 2=CRITICAL (150%+) — synced for warning display / UA: 0=норма, 1=ВИСОКЕ (120%+), 2=КРИТИЧНЕ (150%+)
+        overloadLevel = 0,     -- EN: 0=normal, 1=HIGH (120%+), 2=CRITICAL (150%+) — synced for warning display / UA: 0=норма, 1=ВИСОКЕ (120%+), 2=КРИТИЧНЕ (150%+)
+        isPlugged = false,     -- EN: True when rotor plug is active / UA: True коли активне засмічення ротора
+        moistureLabel = "",    -- EN: Short label for current moisture condition / UA: Коротка мітка поточного стану вологості
+        plugTimerPct = 0,      -- EN: 0-100% progress toward plug (for HUD warning ramp-up) / UA: 0-100% прогрес до засмічення
     }
+
+    -- EN: Start session tracking immediately on load.
+    -- UA: Починаємо відстеження сесії відразу при завантаженні.
+    spec.loadCalculator:startSession()
     
     -- Лічильник для збереження площі з addCutterArea
     spec.lastArea = 0
@@ -573,7 +583,15 @@ function rhm_Combine:getSpeedLimit(superFunc, onlyIfWorking)
     if not spec or not spec.loadCalculator then
         return limit, doCheckSpeedLimit
     end
-    
+
+    -- EN: PLUG OVERRIDE: When rotor is plugged, bring the combine to a near-stop (1 km/h).
+    --     This applies regardless of Speed Control tier — a plugged combine cannot move.
+    -- UA: ПЕРЕВИЗНАЧЕННЯ ПРИ ЗАСМІЧЕННІ: При засміченні ротора зупиняємо комбайн (1 км/год).
+    if spec.loadCalculator.isPlugged then
+        spec.isSpeedLimitActive = true
+        return math.min(limit, 1.0), doCheckSpeedLimit
+    end
+
     -- EN: Skip speed limiting if the thresher is off.
     -- UA: Пропускаємо обмеження швидкості якщо молотарка вимкнена.
     if not self:getIsTurnedOn() then
@@ -620,13 +638,21 @@ function rhm_Combine:getSpeedLimit(superFunc, onlyIfWorking)
             spec.isSpeedLimitActive = false
             return limit, doCheckSpeedLimit
         end
-        
+
         -- EN: In Arcade difficulty mode, don't limit speed (like vanilla game).
         -- UA: В режимі складності Arcade не обмежуємо швидкість (як у ванільній грі).
         if g_realisticHarvestManager.settings.difficultyMotor == 1 then -- DIFFICULTY_ARCADE
             spec.isSpeedLimitActive = false
             return limit, doCheckSpeedLimit
         end
+    end
+
+    -- EN: Speed Control upgrade (Tier 3) required for automatic speed limiting.
+    --     Without it, players must manage speed manually — no automation.
+    -- UA: Для автоматичного обмеження швидкості потрібен апгрейд Speed Control (Рівень 3).
+    if spec.combineMemory and (spec.combineMemory.upgradeLevel or 0) < 3 then
+        spec.isSpeedLimitActive = false
+        return limit, doCheckSpeedLimit
     end
     
     -- EN: If the cutter changed, reset genuineSpeedLimit to recalibrate for the new header's speed range.
@@ -997,6 +1023,10 @@ function rhm_Combine:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSe
     -- UA: Використовуємо lastRawArea (реальну геометричну площу) для розрахунку врожайності.
     local areaForYield = spec.lastRawArea or spec.lastArea or 0 
     
+    -- EN: Update time-of-day moisture factor (cached, cheap call).
+    -- UA: Оновлюємо коефіцієнт вологості часу доби (кешується, дешевий виклик).
+    spec.loadCalculator:updateMoistureFactor(dt)
+
     -- EN: Pass accumulated MASS to LoadCalculator (not area) — mass is the main driver now.
     -- UA: Передаємо накопичену МАСУ в LoadCalculator (не площу) — маса тепер основний показник.
     spec.loadCalculator:update(self, dt, massKg)
@@ -1007,6 +1037,21 @@ function rhm_Combine:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSe
     --     щоб показник т/год плавно падав до 0 між проходами.
     spec.loadCalculator:updateProductivityAndYield(massKg, liters, areaForYield, dt) 
     
+    -- EN: Calculate header loss based on current travel speed (server side only).
+    -- UA: Розраховуємо втрати на жатці виходячи з поточної швидкості (тільки на сервері).
+    local headerLoss = spec.loadCalculator:calculateHeaderLoss(self)
+
+    -- EN: Update plug state machine — 130%+ load for 10s → plug.
+    -- UA: Оновлюємо стан засмічення — навантаження 130%+ протягом 10с → засмічення.
+    local plugChanged = spec.loadCalculator:updatePlugState(dt)
+    if plugChanged and spec.loadCalculator.isPlugged then
+        -- EN: Plug event — show warning. Speed automation will force speed to ~0.
+        -- UA: Подія засмічення — показуємо попередження.
+        if g_i18n then
+            g_currentMission:showBlinkingWarning(g_i18n:getText("rhm_warn_rotor_plugged"), 8000)
+        end
+    end
+
     -- EN: Apply physical crop loss: remove lost grain from the fill unit on the server.
     --     This makes crop loss visible as a real reduction in tank fill level.
     -- UA: Застосовуємо фізичні втрати врожаю: видаляємо втрачене зерно з fill unit на сервері.
@@ -1016,6 +1061,10 @@ function rhm_Combine:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSe
         -- UA: Розраховуємо загальні втрати врожаю включаючи штраф за відхилення налаштувань.
         local cropLoss = spec.loadCalculator:calculateTotalCropLoss()
         spec.combineMemory:updateStatistics(liters, cropLoss, spec.combineMemory.currentCrop)
+
+        -- EN: Update session statistics.
+        -- UA: Оновлюємо статистику сесії.
+        spec.loadCalculator:updateSession(massKg, areaForYield, cropLoss, headerLoss)
         
         if cropLoss > 0 and g_realisticHarvestManager and g_realisticHarvestManager.settings then
             if g_realisticHarvestManager.settings.enableCropLoss then
@@ -1056,13 +1105,25 @@ function rhm_Combine:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSe
     -- EN: Update HUD live data table from LoadCalculator outputs.
     -- UA: Оновлюємо таблицю живих даних HUD з виводів LoadCalculator.
     if spec.data then
-        spec.data.load = spec.loadCalculator:getEngineLoad()
-        spec.data.cropLoss = spec.loadCalculator:calculateTotalCropLoss()
-        spec.data.tonPerHour = spec.loadCalculator:getTonPerHour()
-        spec.data.litersPerHour = spec.loadCalculator:getLitersPerHour() -- NEW: Volume flow
-        spec.data.recommendedSpeed = spec.loadCalculator:getSpeedLimit()
-        -- NEW: Yield Monitor Data
-        spec.data.yield = spec.loadCalculator.currentYield or 0
+        local lc = spec.loadCalculator
+        spec.data.load             = lc:getEngineLoad()
+        spec.data.cropLoss         = lc:calculateTotalCropLoss()
+        spec.data.headerLoss       = lc.headerLoss or 0
+        spec.data.tonPerHour       = lc:getTonPerHour()
+        spec.data.litersPerHour    = lc:getLitersPerHour()
+        spec.data.yield            = lc.currentYield or 0
+        spec.data.isPlugged        = lc.isPlugged or false
+        spec.data.moistureLabel    = lc.moistureLabel or ""
+        -- EN: plugTimerPct: 0-100% progress toward a plug, for HUD pre-warning ramp.
+        -- UA: plugTimerPct: 0-100% прогрес до засмічення для попереднього попередження HUD.
+        spec.data.plugTimerPct     = math.min(100, ((lc.plugTimer or 0) / 10000) * 100)
+        -- EN: Speed limit — if plugged, force 0 km/h regardless of Speed Control tier.
+        -- UA: Ліміт швидкості — при засміченні форсуємо 0 км/год незалежно від рівня апгрейду.
+        if lc.isPlugged then
+            spec.data.recommendedSpeed = 0
+        else
+            spec.data.recommendedSpeed = lc:getSpeedLimit()
+        end
     end
     
     -- === AI / COURSEPLAY WORKAROUND (Server Side) ===
@@ -1074,10 +1135,19 @@ function rhm_Combine:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSe
             local motor = self.spec_motorized.motor
             local currentLimit = spec.loadCalculator:getSpeedLimit()
             
-            -- If the AI tries to drive faster than our dynamic limit, force the motor to slow down
-            if motor.speedLimit > currentLimit then
-                motor:setSpeedLimit(currentLimit)
+            -- EN: ALWAYS apply the calculated limit (both up and down).
+            --     Previously we only called setSpeedLimit when lowering, so after a heavy windrow
+            --     the motor limit stayed at 1-2 km/h permanently (Courseplay speed-lock bug).
+            --     Cap at genuineSpeedLimit so we never restore above the original ceiling.
+            -- UA: ЗАВЖДИ застосовуємо розрахований ліміт (і вниз, і вгору).
+            --     Раніше ми викликали setSpeedLimit лише при зниженні, тому після важких рядків
+            --     ліміт мотора назавжди залишався на 1-2 км/год (баг блокування швидкості Courseplay).
+            --     Обмежуємо genuineSpeedLimit щоб не перевищити оригінальну стелю.
+            local ceiling = spec.loadCalculator.genuineSpeedLimit
+            if ceiling and ceiling > 0 then
+                currentLimit = math.min(currentLimit, ceiling)
             end
+            motor:setSpeedLimit(currentLimit)
         end
     end
     
@@ -1152,17 +1222,21 @@ function rhm_Combine:onUpdateTick(dt, isActiveForInput, isActiveForInputIgnoreSe
                 elseif math.abs((data.recommendedSpeed or 0) - (last.recommendedSpeed or 0)) > 0.2 then hasSignificantChange = true
                 elseif math.abs((data.yield or 0) - (last.yield or 0)) > 0.1 then hasSignificantChange = true
                 elseif data.overloadLevel ~= last.overloadLevel then hasSignificantChange = true
+                elseif (data.isPlugged ~= last.isPlugged) then hasSignificantChange = true
+                elseif math.abs((data.headerLoss or 0) - (last.headerLoss or 0)) > 0.3 then hasSignificantChange = true
                 end
             end
             
             -- Також форсуємо оновлення раз на секунду
             if hasSignificantChange or (now - spec.lastDataUpdateTime) >= 1000 then
                 spec.lastDataUpdateTime = now
-                spec.lastSyncedData.load = data.load
-                spec.lastSyncedData.cropLoss = data.cropLoss
-                spec.lastSyncedData.recommendedSpeed = data.recommendedSpeed
-                spec.lastSyncedData.yield = data.yield
-                spec.lastSyncedData.overloadLevel = data.overloadLevel
+                spec.lastSyncedData.load            = data.load
+                spec.lastSyncedData.cropLoss        = data.cropLoss
+                spec.lastSyncedData.headerLoss      = data.headerLoss
+                spec.lastSyncedData.recommendedSpeed= data.recommendedSpeed
+                spec.lastSyncedData.yield           = data.yield
+                spec.lastSyncedData.overloadLevel   = data.overloadLevel
+                spec.lastSyncedData.isPlugged       = data.isPlugged
                 
                 self:raiseDirtyFlags(spec.dataDirtyFlag)
             end
@@ -1204,15 +1278,22 @@ function rhm_Combine:saveToXMLFile(xmlFile, key, usedModNames)
         end
     end
     
-    safeSet(cur .. "#mode",       mem.mode or "AUTO")
-    safeSet(cur .. "#autoSwitch", mem.autoSwitchEnabled ~= false)
-    safeSet(cur .. "#currentCrop", mem.currentCrop or "")
-    safeSet(cur .. "#fan",        settings.fan or 50)
-    safeSet(cur .. "#upperSieve", settings.upperSieve or 50)
-    safeSet(cur .. "#lowerSieve", settings.lowerSieve or 50)
-    safeSet(cur .. "#rotor",      settings.rotor or 50)
-    safeSet(cur .. "#feeder",     settings.feeder or 50)
-    
+    safeSet(cur .. "#mode",         mem.mode or "AUTO")
+    safeSet(cur .. "#autoSwitch",   mem.autoSwitchEnabled ~= false)
+    safeSet(cur .. "#currentCrop",  mem.currentCrop or "")
+    safeSet(cur .. "#fan",          settings.fan or 50)
+    safeSet(cur .. "#upperSieve",   settings.upperSieve or 50)
+    safeSet(cur .. "#lowerSieve",   settings.lowerSieve or 50)
+    safeSet(cur .. "#rotor",        settings.rotor or 50)
+    safeSet(cur .. "#upgradeLevel", mem.upgradeLevel or 0)
+    -- EN: Save concave (grain) or feeder (forage/root/cotton) under their respective keys.
+    --     Both keys registered in schema; unused one gets 50 (default).
+    if spec.machineType == "grain" then
+        safeSet(cur .. "#concave", settings.concave or 50)
+    else
+        safeSet(cur .. "#feeder",  settings.feeder or 50)
+    end
+
     print(string.format("RHM: [SAVE] Saved combine state for %s", self:getName() or "?"))
 end
 
@@ -1231,8 +1312,18 @@ function rhm_Combine:loadFromXMLFile(xmlFile, key, resetVehicles)
     spec.combineMemory.currentSettings.upperSieve = xmlFile:getValue(cur .. "#upperSieve", 50)
     spec.combineMemory.currentSettings.lowerSieve = xmlFile:getValue(cur .. "#lowerSieve", 50)
     spec.combineMemory.currentSettings.rotor      = xmlFile:getValue(cur .. "#rotor", 50)
-    spec.combineMemory.currentSettings.feeder     = xmlFile:getValue(cur .. "#feeder", 50)
-    
+    spec.combineMemory.upgradeLevel               = xmlFile:getValue(cur .. "#upgradeLevel", 0)
+    -- EN: Load the correct 5th parameter key based on machine type.
+    --     Grain combines use 'concave'; fall back to '#feeder' for old saves.
+    --     Forage/root/cotton use 'feeder'.
+    if spec.machineType == "grain" then
+        local concaveVal = xmlFile:getValue(cur .. "#concave", nil)
+        local feederFallback = xmlFile:getValue(cur .. "#feeder", 50)
+        spec.combineMemory.currentSettings.concave = concaveVal or feederFallback
+    else
+        spec.combineMemory.currentSettings.feeder = xmlFile:getValue(cur .. "#feeder", 50)
+    end
+
     print(string.format("RHM: [LOAD] Loaded combine state for %s", self:getName() or "?"))
 end
 
@@ -1257,9 +1348,10 @@ function rhm_Combine:onWriteStream(streamId, connection)
         streamWriteUInt8(streamId, 50)  -- rotor
         streamWriteUInt8(streamId, 50)  -- upperSieve
         streamWriteUInt8(streamId, 50)  -- lowerSieve
-        streamWriteUInt8(streamId, 50)  -- feeder
+        streamWriteUInt8(streamId, 50)  -- slot5 (concave/feeder)
         streamWriteString(streamId, "AUTO")  -- mode
         streamWriteString(streamId, "")      -- currentCrop (empty = nil)
+        streamWriteUInt8(streamId, 0)        -- upgradeLevel
         return
     end
     
@@ -1272,24 +1364,27 @@ function rhm_Combine:onWriteStream(streamId, connection)
     streamWriteFloat32(streamId, spec.data.yield or 0)
     streamWriteUInt8(streamId, spec.data.overloadLevel or 0)
     
-    -- CombineMemory settings (FIX 4: sync on initial connect)
+    -- CombineMemory settings (sync on initial connect)
     local mem = spec.combineMemory
     if mem then
         streamWriteUInt8(streamId, mem.currentSettings.fan or 50)
         streamWriteUInt8(streamId, mem.currentSettings.rotor or 50)
         streamWriteUInt8(streamId, mem.currentSettings.upperSieve or 50)
         streamWriteUInt8(streamId, mem.currentSettings.lowerSieve or 50)
-        streamWriteUInt8(streamId, mem.currentSettings.feeder or 50)
+        -- EN: slot5 = concave (grain) or feeder (forage/root/cotton)
+        streamWriteUInt8(streamId, mem.currentSettings.concave or mem.currentSettings.feeder or 50)
         streamWriteString(streamId, mem.mode or "AUTO")
         streamWriteString(streamId, mem.currentCrop or "")
+        streamWriteUInt8(streamId, mem.upgradeLevel or 0)
     else
         streamWriteUInt8(streamId, 50)
         streamWriteUInt8(streamId, 50)
         streamWriteUInt8(streamId, 50)
         streamWriteUInt8(streamId, 50)
-        streamWriteUInt8(streamId, 50)
+        streamWriteUInt8(streamId, 50)  -- slot5
         streamWriteString(streamId, "AUTO")
         streamWriteString(streamId, "")
+        streamWriteUInt8(streamId, 0)   -- upgradeLevel
     end
 end
 
@@ -1310,9 +1405,10 @@ function rhm_Combine:onReadStream(streamId, connection)
         streamReadUInt8(streamId)
         streamReadUInt8(streamId)
         streamReadUInt8(streamId)
-        streamReadUInt8(streamId)
+        streamReadUInt8(streamId)  -- slot5
         streamReadString(streamId)
         streamReadString(streamId)
+        streamReadUInt8(streamId)  -- upgradeLevel
         return
     end
     
@@ -1334,19 +1430,26 @@ function rhm_Combine:onReadStream(streamId, connection)
     local rotor = streamReadUInt8(streamId)
     local upperSieve = streamReadUInt8(streamId)
     local lowerSieve = streamReadUInt8(streamId)
-    local feeder = streamReadUInt8(streamId)
+    local slot5 = streamReadUInt8(streamId)   -- concave (grain) or feeder (forage/root/cotton)
     local mode = streamReadString(streamId)
     local currentCrop = streamReadString(streamId)
-    
+    local upgradeLevel = streamReadUInt8(streamId)
+
     -- Apply to combineMemory if available
     if spec.combineMemory then
         spec.combineMemory.currentSettings.fan = fan
         spec.combineMemory.currentSettings.rotor = rotor
         spec.combineMemory.currentSettings.upperSieve = upperSieve
         spec.combineMemory.currentSettings.lowerSieve = lowerSieve
-        spec.combineMemory.currentSettings.feeder = feeder
+        -- EN: Apply slot5 to the key that exists in this machine's settings table.
+        if spec.combineMemory.currentSettings.concave ~= nil then
+            spec.combineMemory.currentSettings.concave = slot5
+        elseif spec.combineMemory.currentSettings.feeder ~= nil then
+            spec.combineMemory.currentSettings.feeder = slot5
+        end
         spec.combineMemory.mode = mode or "AUTO"
         spec.combineMemory.currentCrop = (currentCrop ~= "" and currentCrop) or nil
+        spec.combineMemory.upgradeLevel = upgradeLevel or 0
     end
 end
 
@@ -1368,13 +1471,16 @@ function rhm_Combine:onReadUpdateStream(streamId, timestamp, connection)
             end
             
             -- HUD data
-            spec.data.load = streamReadFloat32(streamId)
-            spec.data.cropLoss = streamReadFloat32(streamId)
-            spec.data.tonPerHour = streamReadFloat32(streamId)
-            spec.data.litersPerHour = streamReadFloat32(streamId)
+            spec.data.load             = streamReadFloat32(streamId)
+            spec.data.cropLoss         = streamReadFloat32(streamId)
+            spec.data.headerLoss       = streamReadFloat32(streamId)
+            spec.data.tonPerHour       = streamReadFloat32(streamId)
+            spec.data.litersPerHour    = streamReadFloat32(streamId)
             spec.data.recommendedSpeed = streamReadFloat32(streamId)
-            spec.data.yield = streamReadFloat32(streamId)
-            spec.data.overloadLevel = streamReadUInt8(streamId)
+            spec.data.yield            = streamReadFloat32(streamId)
+            spec.data.overloadLevel    = streamReadUInt8(streamId)
+            spec.data.isPlugged        = streamReadBool(streamId)
+            spec.data.plugTimerPct     = streamReadUInt8(streamId)
         end
 
         if hasSettingsUpdate then
@@ -1383,18 +1489,24 @@ function rhm_Combine:onReadUpdateStream(streamId, timestamp, connection)
             local rotor = streamReadUInt8(streamId)
             local upperSieve = streamReadUInt8(streamId)
             local lowerSieve = streamReadUInt8(streamId)
-            local feeder = streamReadUInt8(streamId)
+            local slot5 = streamReadUInt8(streamId)  -- concave or feeder
             local mode = streamReadString(streamId)
             local currentCrop = streamReadString(streamId)
-            
+            local upgradeLevel = streamReadUInt8(streamId)
+
             if spec.combineMemory then
                 spec.combineMemory.currentSettings.fan = fan
                 spec.combineMemory.currentSettings.rotor = rotor
                 spec.combineMemory.currentSettings.upperSieve = upperSieve
                 spec.combineMemory.currentSettings.lowerSieve = lowerSieve
-                spec.combineMemory.currentSettings.feeder = feeder
+                if spec.combineMemory.currentSettings.concave ~= nil then
+                    spec.combineMemory.currentSettings.concave = slot5
+                elseif spec.combineMemory.currentSettings.feeder ~= nil then
+                    spec.combineMemory.currentSettings.feeder = slot5
+                end
                 spec.combineMemory.mode = mode or "AUTO"
                 spec.combineMemory.currentCrop = (currentCrop ~= "" and currentCrop) or nil
+                spec.combineMemory.upgradeLevel = upgradeLevel or 0
             end
         end
     end
@@ -1419,13 +1531,16 @@ function rhm_Combine:onWriteUpdateStream(streamId, connection, dirtyMask)
         if hasDataUpdate then
             -- HUD data
             local data = spec.data or {}
-            streamWriteFloat32(streamId, data.load or 0)
-            streamWriteFloat32(streamId, data.cropLoss or 0)
-            streamWriteFloat32(streamId, data.tonPerHour or 0)
-            streamWriteFloat32(streamId, data.litersPerHour or 0)
+            streamWriteFloat32(streamId, data.load             or 0)
+            streamWriteFloat32(streamId, data.cropLoss         or 0)
+            streamWriteFloat32(streamId, data.headerLoss       or 0)
+            streamWriteFloat32(streamId, data.tonPerHour       or 0)
+            streamWriteFloat32(streamId, data.litersPerHour    or 0)
             streamWriteFloat32(streamId, data.recommendedSpeed or 0)
-            streamWriteFloat32(streamId, data.yield or 0)
-            streamWriteUInt8(streamId, data.overloadLevel or 0)
+            streamWriteFloat32(streamId, data.yield            or 0)
+            streamWriteUInt8(streamId,   data.overloadLevel    or 0)
+            streamWriteBool(streamId,    data.isPlugged        or false)
+            streamWriteUInt8(streamId,   math.floor(math.min(100, data.plugTimerPct or 0)))
         end
 
         if hasSettingsUpdate then
@@ -1436,17 +1551,20 @@ function rhm_Combine:onWriteUpdateStream(streamId, connection, dirtyMask)
                 streamWriteUInt8(streamId, mem.currentSettings.rotor or 50)
                 streamWriteUInt8(streamId, mem.currentSettings.upperSieve or 50)
                 streamWriteUInt8(streamId, mem.currentSettings.lowerSieve or 50)
-                streamWriteUInt8(streamId, mem.currentSettings.feeder or 50)
+                -- EN: slot5 = concave (grain) or feeder (forage/root/cotton)
+                streamWriteUInt8(streamId, mem.currentSettings.concave or mem.currentSettings.feeder or 50)
                 streamWriteString(streamId, mem.mode or "AUTO")
                 streamWriteString(streamId, mem.currentCrop or "")
+                streamWriteUInt8(streamId, mem.upgradeLevel or 0)
             else
                 streamWriteUInt8(streamId, 50)
                 streamWriteUInt8(streamId, 50)
                 streamWriteUInt8(streamId, 50)
                 streamWriteUInt8(streamId, 50)
-                streamWriteUInt8(streamId, 50)
+                streamWriteUInt8(streamId, 50)  -- slot5
                 streamWriteString(streamId, "AUTO")
                 streamWriteString(streamId, "")
+                streamWriteUInt8(streamId, 0)   -- upgradeLevel
             end
         end
     end

--- a/src/settings/CombineMemory.lua
+++ b/src/settings/CombineMemory.lua
@@ -8,6 +8,30 @@
 CombineMemory = {}
 local CombineMemory_mt = Class(CombineMemory)
 
+-- ============================================================================
+-- EN: Upgrade tier constants.
+--     Tier 0 (free)   : Manual settings only. No loss display, no hints, no auto.
+--     Tier 1 ($2,500) : Calibration   — live crop loss % shown in HUD.
+--     Tier 2 ($5,000) : Machine Monitor — optimal setting hints shown in GUI.
+--     Tier 3 ($20,000): Auto Pilot    — combine self-applies optimal settings on crop change.
+--     Each tier includes all lower tiers. Purchased once per combine (not per farm).
+-- UA: Константи рівнів апгрейду.
+-- ============================================================================
+CombineMemory.UPGRADE_COSTS = { [1] = 2500, [2] = 5000, [3] = 10000, [4] = 20000 }
+CombineMemory.UPGRADE_NAMES = {
+    [0] = "No Upgrade",
+    [1] = "Calibration System",
+    [2] = "Machine Monitor",
+    [3] = "Speed Control",
+    [4] = "Auto Pilot",
+}
+CombineMemory.UPGRADE_DESC = {
+    [1] = "Shows live crop loss % and header loss in HUD",
+    [2] = "Shows optimal settings hints and yield trend in GUI",
+    [3] = "Activates automatic speed control to prevent overloads and plugging",
+    [4] = "Auto-applies optimal settings on crop change",
+}
+
 -- EN: Creates a new CombineMemory instance tied to a specific combine vehicle.
 --     Initializes all parameters to 50% and sets AUTO mode as default.
 -- UA: Створює новий екземпляр CombineMemory, прив'язаний до конкретного комбайна.
@@ -30,14 +54,70 @@ function CombineMemory.new(combine, machineType)
     for _, paramName in ipairs(activeParams) do
         self.currentSettings[paramName] = 50
     end
+    self.currentSettings["targetEngineLoad"] = 95
 
     self.currentYieldCalibration = 1.0
+
+    -- EN: Upgrade level: 0=None, 1=Calibration($2500), 2=Monitor($5000), 3=AutoPilot($20000).
+    --     Each tier is purchased once per combine and persists in the savegame.
+    -- UA: Рівень апгрейду: 0=Відсутній, 1=Калібрування, 2=Моніторинг, 3=Автопілот.
+    self.upgradeLevel = 0
 
     self.mode = "AUTO"            -- EN: Starts in AUTO mode by default / UA: За замовчуванням починає в AUTO режимі
     self.autoSwitchEnabled = true -- EN: Auto-applies optimal settings on crop change / UA: Автоматично застосовує оптимальні при зміні культури
     self.showWarnings = true      -- EN: Show warnings for incorrect settings / UA: Показувати попередження при неправильних налаштуваннях
 
     return self
+end
+
+-- EN: Attempts to purchase the specified upgrade tier for this combine.
+--     Deducts cost from the player's farm budget. Sends a network sync event.
+--     Returns true + "success" on success, or false + reason string on failure.
+--     Buying tier 3 directly skips tier 1 and 2 (you get all features).
+-- UA: Намагається придбати вказаний рівень апгрейду для цього комбайна.
+function CombineMemory:purchaseUpgrade(targetLevel)
+    if targetLevel <= (self.upgradeLevel or 0) then
+        return false, "already_owned"
+    end
+    if targetLevel < 1 or targetLevel > 4 then
+        return false, "invalid_level"
+    end
+
+    local cost = CombineMemory.UPGRADE_COSTS[targetLevel] or 0
+
+    -- EN: Resolve player farm and check balance.
+    local farmId = g_currentMission and g_currentMission.player and g_currentMission.player.farmId
+    local farm   = farmId and g_farmManager and g_farmManager:getFarmById(farmId)
+    if not farm then
+        return false, "no_farm"
+    end
+
+    local balance = farm.money or 0
+    if balance < cost then
+        return false, "insufficient_funds"
+    end
+
+    -- EN: Deduct money. FS25 uses addMoney with negative value + MoneyType.
+    g_currentMission:addMoney(-cost, farmId, MoneyType.SHOP_PROPERTY_BUY, true, true)
+
+    self.upgradeLevel = targetLevel
+
+    -- EN: Sync upgrade level to server / all clients via CombineSettingsEvent.
+    if g_client and self.combine then
+        local event = CombineSettingsEvent.new(self.combine, "UPGRADE_LEVEL", targetLevel)
+        if not g_server then
+            g_client:getServerConnection():sendEvent(event)
+        else
+            local conn = g_currentMission and g_currentMission.player and g_currentMission.player.serverConnection or nil
+            event:run(conn)
+        end
+    end
+
+    if self.debug then
+        print(string.format("RHM: [Upgrade] Purchased tier %d (%s) for $%d",
+            targetLevel, CombineMemory.UPGRADE_NAMES[targetLevel] or "?", cost))
+    end
+    return true, "success"
 end
 
 -- EN: Saves the current settings as a global profile for the given crop in ProfileManager.
@@ -196,7 +276,14 @@ function CombineMemory:loadUserPreset()
             self.currentSettings.rotor = profile.rotor
             self.currentSettings.upperSieve = profile.upperSieve
             self.currentSettings.lowerSieve = profile.lowerSieve
-            self.currentSettings.feeder = profile.feeder
+            -- EN: Grain combines use 'concave'; forage/root/cotton still use 'feeder'.
+            --     Load 'concave' from profile, falling back to legacy 'feeder' key for old saves.
+            if self.currentSettings.concave ~= nil then
+                self.currentSettings.concave = profile.concave or profile.feeder or 50
+            else
+                self.currentSettings.feeder = profile.feeder or 50
+            end
+            self.currentSettings.targetEngineLoad = profile.targetEngineLoad or 95
             self.mode = "MANUAL"
             self.autoSwitchEnabled = false
         end
@@ -224,6 +311,9 @@ function CombineMemory:checkSettingsForCrop(cropName)
     local warnings = {}
     local efficiencyScore = 0  -- EN: Impacts throughput/speed / UA: Впливає на пропускну здатність/швидкість
     local lossScore = 0        -- EN: Impacts direct crop loss / UA: Впливає на прямі втрати врожаю
+    
+    local effParamCount = 0
+    local lossParamCount = 0
 
     for param, value in pairs(self.currentSettings) do
         if optimalSettings[param] then
@@ -252,18 +342,38 @@ function CombineMemory:checkSettingsForCrop(cropName)
             end
 
             -- EN: Route penalty to the appropriate physical effect based on parameter type.
-            --     Feeder/Rotor → efficiency (speed) | Fan/Sieves → loss (separation).
+            --     Rotor/Feeder/Concave → efficiency (threshing throughput).
+            --     Fan/Sieves → loss (separation quality).
+            --     Concave (grain) affects threshing intensity — too open = unthreshed grain (loss),
+            --     too tight = grain cracking (efficiency). We route it to efficiency as a simplification.
             -- UA: Направляємо штраф до відповідного фізичного ефекту залежно від параметру.
-            --     Подача/Ротор → ефективність (швидкість) | Вентилятор/Решета → втрати (очищення).
-            if param == "feeder" or param == "rotor" then
+            if param == "feeder" or param == "rotor" or param == "concave" then
                 efficiencyScore = efficiencyScore + score
+                effParamCount = effParamCount + 1
             elseif param == "fan" or param == "upperSieve" or param == "lowerSieve" then
                 lossScore = lossScore + score
+                lossParamCount = lossParamCount + 1
             else
                 efficiencyScore = efficiencyScore + (score * 0.5)
                 lossScore = lossScore + (score * 0.5)
+                effParamCount = effParamCount + 0.5
+                lossParamCount = lossParamCount + 0.5
             end
         end
+    end
+
+    -- EN: Normalize scores so that machines with fewer parameters (e.g., forage/root)
+    --     can still reach the same max bonus and max penalty as 5-parameter grain combines.
+    -- UA: Нормалізуємо бали, щоб машини з меншою кількістю параметрів (напр., форажні/бурякові)
+    --     могли досягати тих же максимальних бонусів/штрафів, що й 5-параметрові зернові комбайни.
+    if effParamCount > 0 then
+        -- Grain combines have 2 efficiency params (feeder, rotor). We scale to 2.
+        efficiencyScore = efficiencyScore * (2.0 / effParamCount)
+    end
+    
+    if lossParamCount > 0 then
+        -- Grain combines have 3 loss params (fan, upperSieve, lowerSieve). We scale to 3.
+        lossScore = lossScore * (3.0 / lossParamCount)
     end
 
     -- EN: Clamp penalties to reasonable bounds.
@@ -282,6 +392,10 @@ end
 -- UA: Встановлює значення одного параметру (0-100) і перемикає в MANUAL режим.
 function CombineMemory:setParameter(paramName, value)
     if self.currentSettings[paramName] ~= nil then
+        if paramName == "targetEngineLoad" then
+            self.currentSettings[paramName] = math.max(70, math.min(110, value))
+            return true
+        end
         self.currentSettings[paramName] = math.max(0, math.min(100, value))
         self.mode = "MANUAL" -- EN: Any manual change overrides AUTO mode / UA: Будь-яка ручна зміна скасовує AUTO режим
         return true
@@ -389,7 +503,11 @@ function CombineMemory:switchCrop(newCropName)
         self:loadUserPreset()
     else
         if self.debug then print(string.format("RHM: Switching to crop %s - No profile, applying defaults", newCropName)) end
-        if self.autoSwitchEnabled then
+        -- EN: Auto-apply optimal settings only if Auto Pilot upgrade (tier 4) is installed.
+        --     Lower tiers keep 50% neutral defaults — player must set manually.
+        -- UA: Автоматичне застосування оптимальних налаштувань тільки з апгрейдом Автопілот (рівень 4).
+        local hasAutoPilot = (self.upgradeLevel or 0) >= 4
+        if self.autoSwitchEnabled and hasAutoPilot then
             self:autoConfigureForCrop(newCropName, true)
         else
             self:autoConfigureForCrop(newCropName, false)
@@ -409,8 +527,10 @@ end
 function CombineMemory:updateSetting(param, value)
     local success = self:setParameter(param, value)
     if success then
-        self.autoSwitchEnabled = false
-        self.mode = "MANUAL"
+        if param ~= "targetEngineLoad" then
+            self.autoSwitchEnabled = false
+            self.mode = "MANUAL"
+        end
 
         if g_client and self.combine then
             local event = CombineSettingsEvent.new(self.combine, param, self.currentSettings[param], false, nil)

--- a/src/settings/ProfileManager.lua
+++ b/src/settings/ProfileManager.lua
@@ -73,7 +73,8 @@ function ProfileManager:loadProfiles()
                     rotor = xml:getInt(key .. "#rotor", 50),
                     upperSieve = xml:getInt(key .. "#upperSieve", 50),
                     lowerSieve = xml:getInt(key .. "#lowerSieve", 50),
-                    feeder = xml:getInt(key .. "#feeder", 50)
+                    feeder = xml:getInt(key .. "#feeder", 50),
+                    targetEngineLoad = xml:getInt(key .. "#targetEngineLoad", 95)
                 }
             end
             i = i + 1
@@ -104,6 +105,7 @@ function ProfileManager:saveProfiles()
             xml:setInt(key .. "#upperSieve", settings.upperSieve or 50)
             xml:setInt(key .. "#lowerSieve", settings.lowerSieve or 50)
             xml:setInt(key .. "#feeder", settings.feeder or 50)
+            xml:setInt(key .. "#targetEngineLoad", settings.targetEngineLoad or 95)
             i = i + 1
         end
         xml:save()
@@ -133,7 +135,8 @@ function ProfileManager:saveProfile(cropName, settings)
         rotor = settings.rotor or 50,
         upperSieve = settings.upperSieve or 50,
         lowerSieve = settings.lowerSieve or 50,
-        feeder = settings.feeder or 50
+        feeder = settings.feeder or 50,
+        targetEngineLoad = settings.targetEngineLoad or 95
     }
 
     self:saveProfiles()


### PR DESCRIPTION
…est report, throughput curve

## New Features

### Upgrade System (4 tiers, per-combine)
- Tier 0: Free baseline
- Tier 1 – Calibration System ($2,500): live crop loss + header loss in HUD
- Tier 2 – Machine Monitor ($5,000): hints, yield trend in GUI
- Tier 3 – Speed Control ($10,000): automatic speed management to prevent overloads/plugging
- Tier 4 – Auto Pilot ($20,000): auto-applies optimal settings on crop change (was Tier 3)

### Rotor Plugging
- Engine load >= 130% for 10 consecutive seconds triggers a rotor plug
- Combine forced to 1 km/h for 12-second clear time
- Blinking HUD warning + pre-warning ramp at 50%+ of plug timer
- Speed Control (Tier 3) prevents plugging by keeping load in check

### Header Loss
- Speed-dependent loss separate from threshing loss
- Power-law curve: excess speed above 9.65 km/h, capped at 8%
- Crop-specific multipliers: canola 2.0x, soybean 1.8x, sunflower 1.5x, corn 0.25x
- Displayed in HUD (Tier 1+), tracked in session stats

### Time-of-Day Moisture Effect
- Morning dew (6-9am): +15% effective load; optimal window 10:30am-5pm: baseline
- Evening humidity, dew, and night conditions add 5-12% load
- Cached every 60s; moisture label shown in HUD (Tier 1+)

### Harvest Report (Tier 1+)
- Session stats: time, area, yield, avg/peak load, threshing + header loss, plug count
- Efficiency grade A-F with colour-coded display in CombineCalibrationGUI
- RESET SESSION button; session persists through field stops

### Dynamic Hints (Tier 2)
- Stats bar proactively hints: high load, header loss, rotor plugged, under-utilized

### AEM Class-Anchored Throughput Curve
- New CropThroughputConfig module reads cropThroughput.xml
- Per-crop power-law derived from two anchor points: buPerHrMin = AEM Class 6 (~280 hp) throughput buPerHrMax = AEM Class 10 (~750 hp) throughput Formula: throughput = A * hp^B  (B and A solved per-crop)
- Bundled default ships with mod; user override via modSettings/
- Replaces generic 0.75-exponent single-reference approach

## Technical
- New multiplayer stream fields: headerLoss (float32), isPlugged (bool), plugTimerPct (uint8)
- Session stats preserved across field stops; manual reset only
- l10n strings added for all new UI elements (11 languages)